### PR TITLE
feat(types): define type system foundation — editor, toolbar, plugin types

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 2 / 25 phases complete | **8% done**
+**Overall:** 3 / 25 phases complete | **12% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -19,7 +19,7 @@
 |---|-------|--------|---------|-----------|-------|
 | 1 | Yarn 4, Package Manager & Git Hygiene | `Complete` | 2026-03-15 | 2026-03-15 | Yarn 4.13.0; ESLint pinned to v9 for plugin compat |
 | 2 | TypeScript, Bundler & Linting Config | `Complete` | 2026-03-15 | 2026-03-15 | Migrated to ESLint v9 flat config; added @eslint/js + globals |
-| 3 | Type System Foundation | `Not Started` | — | — | |
+| 3 | Type System Foundation | `Complete` | 2026-03-15 | 2026-03-15 | All interfaces, types, and constants defined |
 | 4 | Core Engine & Zustand Store | `Not Started` | — | — | |
 | 5 | React Hooks Layer | `Not Started` | — | — | |
 | 6 | Core Components: Editor Shell | `Not Started` | — | — | |
@@ -48,7 +48,7 @@
 | Milestone | Phases | Target | Reached |
 |-----------|--------|--------|---------|
 | **M1 — Buildable project** | 1–2 | — | 2026-03-15 |
-| **M2 — Type-safe foundation** | 3 | — | — |
+| **M2 — Type-safe foundation** | 3 | — | 2026-03-15 |
 | **M3 — Headless engine works** | 4–5 | — | — |
 | **M4 — Editor renders & types** | 6–8 | — | — |
 | **M5 — All features functional** | 9–16 | — | — |
@@ -542,10 +542,10 @@ yarn build         # should produce dist/ with empty exports
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-3-type-system` |
 | **Blocked by** | Phase 2 |
 | **Deliverables** | `src/types/editor.types.ts`, `src/types/toolbar.types.ts`, `src/types/plugin.types.ts`, `src/types/index.ts` |
 
@@ -706,9 +706,9 @@ export * from './plugin.types';
 
 ### Checkpoint
 
-- [ ] `yarn typecheck` passes
-- [ ] All types are importable from `@/types`
-- [ ] No circular dependencies
+- [x] `yarn typecheck` passes
+- [x] All types are importable from `@/types`
+- [x] No circular dependencies
 
 ---
 
@@ -2971,6 +2971,7 @@ Chronological record of implementation progress. Add entries as work is done.
 |------|-------|---------|-------|
 | 2026-03-15 | 1 | Initialized Yarn 4.13.0, populated package.json with full metadata/scripts/exports, installed 5 prod + 21 dev deps, updated .gitignore & README | ESLint pinned to v9 for eslint-plugin-react-hooks compat; added @testing-library/dom as missing peer |
 | 2026-03-15 | 2 | Configured tsconfig.json (strict), tsup (dual ESM/CJS), vitest, ESLint v9 flat config, Prettier | Migrated .eslintrc.cjs → eslint.config.js for ESLint v9; added @eslint/js@9 + globals; rollup config marked as optional fallback |
+| 2026-03-15 | 3 | Defined all TypeScript interfaces: editor types, toolbar types, plugin types, barrel index | No deviations; import graph is acyclic (editor→toolbar, plugin→toolbar) |
 
 <!--
 Example entries:

--- a/src/types/editor.types.ts
+++ b/src/types/editor.types.ts
@@ -1,1 +1,59 @@
-// Placeholder for editor-related TypeScript types
+import type { ToolbarItem } from './toolbar.types';
+
+// --- Theme ---
+export type Theme = 'light' | 'dark';
+
+// --- Dialog Types ---
+export type DialogType = 'link' | 'image';
+
+// --- Editor Props (public API, matches README spec) ---
+export interface RichTextEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+  readOnly?: boolean;
+  toolbar?: ToolbarItem[];
+  theme?: Theme;
+  minHeight?: string | number;
+  maxHeight?: string | number;
+  className?: string;
+  style?: React.CSSProperties;
+  onFocus?: () => void;
+  onBlur?: () => void;
+}
+
+// --- Editor State (internal, for Zustand store) ---
+export interface EditorState {
+  content: string;
+  theme: Theme;
+  readOnly: boolean;
+  isFocused: boolean;
+  activeMarks: Set<string>; // e.g. 'bold', 'italic', 'underline', ...
+  activeNodes: Set<string>; // e.g. 'heading', 'bulletList', ...
+  headingLevel: number | null; // currently active heading level (1-6) or null
+  openDialog: DialogType | null;
+}
+
+// --- Editor Actions (Zustand store actions) ---
+export interface EditorActions {
+  setContent: (content: string) => void;
+  setTheme: (theme: Theme) => void;
+  setReadOnly: (readOnly: boolean) => void;
+  setFocused: (focused: boolean) => void;
+  updateActiveState: (
+    marks: Set<string>,
+    nodes: Set<string>,
+    headingLevel: number | null,
+  ) => void;
+  setOpenDialog: (dialog: DialogType | null) => void;
+}
+
+// --- Editor Config ---
+export interface EditorConfig {
+  placeholder: string;
+  readOnly: boolean;
+  theme: Theme;
+  toolbar: ToolbarItem[];
+  minHeight: string | number;
+  maxHeight?: string | number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
-// Types public exports
+export * from './editor.types';
+export * from './toolbar.types';
+export * from './plugin.types';

--- a/src/types/plugin.types.ts
+++ b/src/types/plugin.types.ts
@@ -1,1 +1,18 @@
-// Placeholder for plugin types
+import type { Extension, Mark, Node } from '@tiptap/core';
+import type { ToolbarItemType } from './toolbar.types';
+
+// --- Plugin Definition ---
+export interface PluginConfig {
+  name: string;
+  extensions: (Extension | Mark | Node)[];
+  toolbarItems?: ToolbarItemType[]; // toolbar items this plugin contributes
+  keyboardShortcuts?: Record<string, () => boolean>; // additional keyboard shortcuts
+}
+
+// --- Plugin Registry ---
+export interface PluginRegistry {
+  plugins: Map<string, PluginConfig>;
+  register: (plugin: PluginConfig) => void;
+  unregister: (name: string) => void;
+  getExtensions: () => (Extension | Mark | Node)[];
+}

--- a/src/types/toolbar.types.ts
+++ b/src/types/toolbar.types.ts
@@ -1,1 +1,68 @@
-// Placeholder for toolbar types
+// --- Toolbar Item Identifiers ---
+export type ToolbarItemType =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strike'
+  | 'heading1'
+  | 'heading2'
+  | 'heading3'
+  | 'heading4'
+  | 'heading5'
+  | 'heading6'
+  | 'bulletList'
+  | 'orderedList'
+  | 'blockquote'
+  | 'code'
+  | 'codeBlock'
+  | 'link'
+  | 'image'
+  | 'undo'
+  | 'redo';
+
+export type ToolbarSeparator = '|';
+
+export type ToolbarItem = ToolbarItemType | ToolbarSeparator;
+
+// --- Toolbar Button Configuration ---
+export interface ToolbarButtonConfig {
+  id: ToolbarItemType;
+  label: string; // Human-readable label (for tooltip / aria-label)
+  icon: React.ReactNode; // Icon element (SVG component or Unicode)
+  action: () => void; // Command to execute when clicked
+  isActive: boolean; // Whether this formatting is currently active at cursor
+  isDisabled: boolean; // Whether the button should be disabled
+  shortcut?: string; // Keyboard shortcut hint (e.g. "Ctrl+B")
+}
+
+// --- Toolbar Group Configuration ---
+export interface ToolbarGroupConfig {
+  id: string;
+  label: string; // Group label for accessibility
+  items: (ToolbarButtonConfig | ToolbarSeparator)[];
+}
+
+// --- Default toolbar item order ---
+export const DEFAULT_TOOLBAR: ToolbarItem[] = [
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  '|',
+  'heading1',
+  'heading2',
+  'heading3',
+  '|',
+  'bulletList',
+  'orderedList',
+  'blockquote',
+  '|',
+  'code',
+  'codeBlock',
+  '|',
+  'link',
+  'image',
+  '|',
+  'undo',
+  'redo',
+];


### PR DESCRIPTION


- editor.types.ts: Theme, DialogType, RichTextEditorProps, EditorState, EditorActions, EditorConfig
- toolbar.types.ts: ToolbarItemType (20 items), ToolbarItem, ToolbarButtonConfig, ToolbarGroupConfig, DEFAULT_TOOLBAR
- plugin.types.ts: PluginConfig, PluginRegistry (imports @tiptap/core Extension/Mark/Node)
- types/index.ts: barrel re-export all type modules
- No circular dependencies (editor→toolbar, plugin→toolbar)
- yarn typecheck ✅  yarn build ✅

Phase 3 complete. Milestone M2 (Type-safe foundation) reached.

