### PR TITLE
feat(phase-4): build core engine, commands, Zustand store, and docume…

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 3 / 25 phases complete | **12% done**
+**Overall:** 4 / 25 phases complete | **16% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -20,7 +20,7 @@
 | 1 | Yarn 4, Package Manager & Git Hygiene | `Complete` | 2026-03-15 | 2026-03-15 | Yarn 4.13.0; ESLint pinned to v9 for plugin compat |
 | 2 | TypeScript, Bundler & Linting Config | `Complete` | 2026-03-15 | 2026-03-15 | Migrated to ESLint v9 flat config; added @eslint/js + globals |
 | 3 | Type System Foundation | `Complete` | 2026-03-15 | 2026-03-15 | All interfaces, types, and constants defined |
-| 4 | Core Engine & Zustand Store | `Not Started` | — | — | |
+| 4 | Core Engine & Zustand Store | `Complete` | 2026-03-15 | 2026-03-15 | schema, engine, commands, store (Zustand), model, barrel |
 | 5 | React Hooks Layer | `Not Started` | — | — | |
 | 6 | Core Components: Editor Shell | `Not Started` | — | — | |
 | 7 | Toolbar System | `Not Started` | — | — | |
@@ -716,10 +716,10 @@ export * from './plugin.types';
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-4-core-engine` |
 | **Blocked by** | Phase 3 |
 | **Deliverables** | `src/core/schema.ts`, `src/core/engine.ts`, `src/core/commands.ts`, `src/core/store.ts`, `src/core/model.ts`, `src/core/index.ts` |
 
@@ -942,9 +942,9 @@ export * from './model';
 
 ### Checkpoint
 
-- [ ] `yarn typecheck` passes
-- [ ] `yarn build` succeeds (store, engine, commands compile)
-- [ ] Can write a simple script that creates an editor instance and executes `toggleBold()`
+- [x] `yarn typecheck` passes
+- [x] `yarn build` succeeds (store, engine, commands compile)
+- [x] Can write a simple script that creates an editor instance and executes `toggleBold()`
 
 ---
 
@@ -2972,6 +2972,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 1 | Initialized Yarn 4.13.0, populated package.json with full metadata/scripts/exports, installed 5 prod + 21 dev deps, updated .gitignore & README | ESLint pinned to v9 for eslint-plugin-react-hooks compat; added @testing-library/dom as missing peer |
 | 2026-03-15 | 2 | Configured tsconfig.json (strict), tsup (dual ESM/CJS), vitest, ESLint v9 flat config, Prettier | Migrated .eslintrc.cjs → eslint.config.js for ESLint v9; added @eslint/js@9 + globals; rollup config marked as optional fallback |
 | 2026-03-15 | 3 | Defined all TypeScript interfaces: editor types, toolbar types, plugin types, barrel index | No deviations; import graph is acyclic (editor→toolbar, plugin→toolbar) |
+| 2026-03-15 | 4 | Built core engine: schema.ts (StarterKit), engine.ts (editor factory), commands.ts (15 commands), store.ts (Zustand), model.ts (HTML↔JSON), barrel | Used insertContent for image cmd (Image ext not yet loaded); fixed no-undef ESLint rule for TS files; added React type imports to Phase 3 files |
 
 <!--
 Example entries:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,8 +52,9 @@ export default [
       // React Hooks rules
       ...reactHooksPlugin.configs.recommended.rules,
 
-      // Disable base rule in favor of TS version
+      // Disable base rules handled by TypeScript
       'no-unused-vars': 'off',
+      'no-undef': 'off', // TypeScript handles this natively and better
     },
   },
 

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,1 +1,81 @@
-// Placeholder for editor commands
+import type { Editor } from '@tiptap/core';
+
+// ──────────────────────────────────────────────
+// Text Formatting
+// ──────────────────────────────────────────────
+
+export const toggleBold = (editor: Editor): boolean =>
+  editor.chain().focus().toggleBold().run();
+
+export const toggleItalic = (editor: Editor): boolean =>
+  editor.chain().focus().toggleItalic().run();
+
+/** Requires Underline extension (Phase 9) */
+export const toggleUnderline = (editor: Editor): boolean =>
+  editor.chain().focus().toggleUnderline().run();
+
+export const toggleStrike = (editor: Editor): boolean =>
+  editor.chain().focus().toggleStrike().run();
+
+// ──────────────────────────────────────────────
+// Headings
+// ──────────────────────────────────────────────
+
+export const setHeading = (editor: Editor, level: 1 | 2 | 3 | 4 | 5 | 6): boolean =>
+  editor.chain().focus().toggleHeading({ level }).run();
+
+// ──────────────────────────────────────────────
+// Lists
+// ──────────────────────────────────────────────
+
+export const toggleBulletList = (editor: Editor): boolean =>
+  editor.chain().focus().toggleBulletList().run();
+
+export const toggleOrderedList = (editor: Editor): boolean =>
+  editor.chain().focus().toggleOrderedList().run();
+
+// ──────────────────────────────────────────────
+// Block Formatting
+// ──────────────────────────────────────────────
+
+export const toggleBlockquote = (editor: Editor): boolean =>
+  editor.chain().focus().toggleBlockquote().run();
+
+export const toggleCode = (editor: Editor): boolean =>
+  editor.chain().focus().toggleCode().run();
+
+export const toggleCodeBlock = (editor: Editor): boolean =>
+  editor.chain().focus().toggleCodeBlock().run();
+
+// ──────────────────────────────────────────────
+// Links (requires Link extension — Phase 11)
+// ──────────────────────────────────────────────
+
+export const insertLink = (editor: Editor, href: string, text?: string): boolean => {
+  if (text) {
+    return editor.chain().focus().insertContent(`<a href="${href}">${text}</a>`).run();
+  }
+  return editor.chain().focus().setLink({ href }).run();
+};
+
+export const removeLink = (editor: Editor): boolean =>
+  editor.chain().focus().unsetLink().run();
+
+// ──────────────────────────────────────────────
+// Images (requires Image extension — Phase 12)
+// ──────────────────────────────────────────────
+
+export const insertImage = (editor: Editor, src: string, alt?: string): boolean =>
+  editor
+    .chain()
+    .focus()
+    .insertContent(`<img src="${src}" alt="${alt || ''}" />`)
+    .run();
+
+// ──────────────────────────────────────────────
+// History
+// ──────────────────────────────────────────────
+
+export const undo = (editor: Editor): boolean => editor.chain().focus().undo().run();
+
+export const redo = (editor: Editor): boolean => editor.chain().focus().redo().run();

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1,1 +1,48 @@
-// Placeholder for headless editor engine
+import { Editor } from '@tiptap/core';
+import { createExtensions } from './schema';
+
+/**
+ * Options for creating a new editor instance.
+ */
+export interface CreateEditorOptions {
+  /** Initial HTML content */
+  content?: string;
+  /** Whether the editor is editable */
+  editable?: boolean;
+  /** Placeholder text shown when the editor is empty */
+  placeholder?: string;
+  /** Called when the editor content changes */
+  onUpdate?: (html: string) => void;
+  /** Called when the selection changes */
+  onSelectionUpdate?: () => void;
+  /** Called when the editor gains focus */
+  onFocus?: () => void;
+  /** Called when the editor loses focus */
+  onBlur?: () => void;
+}
+
+/**
+ * Factory function that creates a headless Tiptap Editor instance.
+ *
+ * This is the single entry point for editor creation. React hooks
+ * (Phase 5) will call this and manage the lifecycle.
+ */
+export function createEditor(options: CreateEditorOptions = {}): Editor {
+  return new Editor({
+    extensions: createExtensions(),
+    content: options.content || '',
+    editable: options.editable ?? true,
+    onUpdate: ({ editor }) => {
+      options.onUpdate?.(editor.getHTML());
+    },
+    onSelectionUpdate: () => {
+      options.onSelectionUpdate?.();
+    },
+    onFocus: () => {
+      options.onFocus?.();
+    },
+    onBlur: () => {
+      options.onBlur?.();
+    },
+  });
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,32 @@
-// Core public exports
+// Schema
+export { createExtensions } from './schema';
+
+// Engine
+export { createEditor } from './engine';
+export type { CreateEditorOptions } from './engine';
+
+// Commands
+export {
+  toggleBold,
+  toggleItalic,
+  toggleUnderline,
+  toggleStrike,
+  setHeading,
+  toggleBulletList,
+  toggleOrderedList,
+  toggleBlockquote,
+  toggleCode,
+  toggleCodeBlock,
+  insertLink,
+  removeLink,
+  insertImage,
+  undo,
+  redo,
+} from './commands';
+
+// Store
+export { useEditorStore } from './store';
+export type { EditorStore } from './store';
+
+// Model
+export { toHTML, fromHTML, createEmptyDoc, isContentEmpty } from './model';

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -1,1 +1,33 @@
-// Placeholder for document model
+import { generateHTML, generateJSON } from '@tiptap/core';
+import type { JSONContent } from '@tiptap/core';
+import { createExtensions } from './schema';
+
+/**
+ * Convert a Tiptap JSON document to an HTML string.
+ */
+export function toHTML(doc: JSONContent): string {
+  return generateHTML(doc, createExtensions());
+}
+
+/**
+ * Convert an HTML string to a Tiptap JSON document.
+ */
+export function fromHTML(html: string): Record<string, unknown> {
+  return generateJSON(html, createExtensions());
+}
+
+/**
+ * Create an empty document as an HTML string.
+ */
+export function createEmptyDoc(): string {
+  return '<p></p>';
+}
+
+/**
+ * Check if the given HTML content is effectively empty.
+ * Strips all tags and checks whether any visible text remains.
+ */
+export function isContentEmpty(html: string): boolean {
+  const stripped = html.replace(/<[^>]*>/g, '').trim();
+  return stripped.length === 0;
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,1 +1,26 @@
-// Placeholder for node/mark schema
+import type { Extensions } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+
+/**
+ * Assemble the base Tiptap extension stack.
+ *
+ * Starts with StarterKit which provides: bold, italic, strike, headings,
+ * bullet list, ordered list, blockquote, code, code block, history,
+ * hard break, horizontal rule, document, paragraph, text.
+ *
+ * Individual plugin phases will add or override extensions:
+ * - Phase 9:  Underline extension
+ * - Phase 11: Link extension
+ * - Phase 12: Image extension
+ * - Phase 13: CodeBlockLowlight (replaces StarterKit's codeBlock)
+ * - Phase 14: Custom history config
+ */
+export function createExtensions(): Extensions {
+  return [
+    StarterKit.configure({
+      // Overrides will be applied in later phases:
+      // history: false,      // Phase 14 — custom history config
+      // codeBlock: false,    // Phase 13 — replaced by code-block-lowlight
+    }),
+  ];
+}

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import type { Editor } from '@tiptap/core';
+import type { EditorState, EditorActions, Theme, DialogType } from '@/types';
+
+/**
+ * The Zustand store — single source of truth for editor state.
+ *
+ * Holds a reference to the Tiptap `Editor` instance so commands
+ * can access it from anywhere via `useEditorStore.getState().editor`.
+ *
+ * Design decisions:
+ * - `activeMarks` / `activeNodes` are `Set<string>` for O(1) lookup
+ *   when rendering toolbar button active states.
+ * - `openDialog` tracks which dialog (link/image) is open; `null` = none.
+ * - Zustand's shallow selectors prevent unnecessary re-renders.
+ */
+export interface EditorStore extends EditorState, EditorActions {
+  /** The Tiptap editor instance (null before initialization, null after destroy) */
+  editor: Editor | null;
+  /** Set or clear the Tiptap editor instance */
+  setEditor: (editor: Editor | null) => void;
+}
+
+export const useEditorStore = create<EditorStore>((set) => ({
+  // ── State ──────────────────────────────────
+  editor: null,
+  content: '',
+  theme: 'light' as Theme,
+  readOnly: false,
+  isFocused: false,
+  activeMarks: new Set<string>(),
+  activeNodes: new Set<string>(),
+  headingLevel: null,
+  openDialog: null as DialogType | null,
+
+  // ── Actions ────────────────────────────────
+  setEditor: (editor) => set({ editor }),
+  setContent: (content) => set({ content }),
+  setTheme: (theme) => set({ theme }),
+  setReadOnly: (readOnly) => set({ readOnly }),
+  setFocused: (focused) => set({ isFocused: focused }),
+  updateActiveState: (marks, nodes, headingLevel) =>
+    set({ activeMarks: marks, activeNodes: nodes, headingLevel }),
+  setOpenDialog: (dialog) => set({ openDialog: dialog }),
+}));

--- a/src/types/editor.types.ts
+++ b/src/types/editor.types.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type { ToolbarItem } from './toolbar.types';
 
 // --- Theme ---

--- a/src/types/toolbar.types.ts
+++ b/src/types/toolbar.types.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 // --- Toolbar Item Identifiers ---
 export type ToolbarItemType =
   | 'bold'


### PR DESCRIPTION

- src/core/schema.ts: StarterKit extension stack with phase override comments
- src/core/engine.ts: createEditor factory with lifecycle callbacks
- src/core/commands.ts: 15 editor commands (bold, italic, underline, strike, headings, lists, blockquote, code, links, images, undo/redo)
- src/core/store.ts: Zustand store with EditorState + EditorActions + editor ref
- src/core/model.ts: toHTML, fromHTML, createEmptyDoc, isContentEmpty utilities
- src/core/index.ts: barrel re-exports for all core modules
- eslint.config.js: disable no-undef for TS files (TypeScript handles natively)
- Fix React type imports in editor.types.ts and toolbar.types.ts

# PR template

Please describe your changes and link any related issues.
