### PR TITLE
feat(phase-5): build React hooks layer — useEditor, useToolbar, useHi story

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 4 / 25 phases complete | **16% done**
+**Overall:** 5 / 25 phases complete | **20% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -21,7 +21,7 @@
 | 2 | TypeScript, Bundler & Linting Config | `Complete` | 2026-03-15 | 2026-03-15 | Migrated to ESLint v9 flat config; added @eslint/js + globals |
 | 3 | Type System Foundation | `Complete` | 2026-03-15 | 2026-03-15 | All interfaces, types, and constants defined |
 | 4 | Core Engine & Zustand Store | `Complete` | 2026-03-15 | 2026-03-15 | schema, engine, commands, store (Zustand), model, barrel |
-| 5 | React Hooks Layer | `Not Started` | — | — | |
+| 5 | React Hooks Layer | `Complete` | 2026-03-15 | 2026-03-15 | useEditor, useToolbar, useHistory; Tiptap v3 setContent API |
 | 6 | Core Components: Editor Shell | `Not Started` | — | — | |
 | 7 | Toolbar System | `Not Started` | — | — | |
 | 8 | Styles & Theming | `Not Started` | — | — | |
@@ -952,10 +952,10 @@ export * from './model';
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-5-react-hooks` |
 | **Blocked by** | Phase 4 |
 | **Deliverables** | `src/hooks/useEditor.ts`, `src/hooks/useToolbar.ts`, `src/hooks/useHistory.ts`, `src/hooks/index.ts` |
 
@@ -1028,9 +1028,9 @@ export { useHistory } from './useHistory';
 
 ### Checkpoint
 
-- [ ] `yarn typecheck` passes
-- [ ] Hooks are syntactically correct and import correctly
-- [ ] No circular dependencies between hooks → store → engine
+- [x] `yarn typecheck` passes
+- [x] Hooks are syntactically correct and import correctly
+- [x] No circular dependencies between hooks → store → engine
 
 ---
 
@@ -2973,6 +2973,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 2 | Configured tsconfig.json (strict), tsup (dual ESM/CJS), vitest, ESLint v9 flat config, Prettier | Migrated .eslintrc.cjs → eslint.config.js for ESLint v9; added @eslint/js@9 + globals; rollup config marked as optional fallback |
 | 2026-03-15 | 3 | Defined all TypeScript interfaces: editor types, toolbar types, plugin types, barrel index | No deviations; import graph is acyclic (editor→toolbar, plugin→toolbar) |
 | 2026-03-15 | 4 | Built core engine: schema.ts (StarterKit), engine.ts (editor factory), commands.ts (15 commands), store.ts (Zustand), model.ts (HTML↔JSON), barrel | Used insertContent for image cmd (Image ext not yet loaded); fixed no-undef ESLint rule for TS files; added React type imports to Phase 3 files |
+| 2026-03-15 | 5 | Built 3 custom React hooks: useEditor (lifecycle, controlled value sync, active state), useToolbar (item→config mapping, actions, active states), useHistory (undo/redo with canUndo/canRedo) | Tiptap v3 changed setContent 2nd param from boolean to SetContentOptions object; icons deferred to Phase 7 Toolbar component |
 
 <!--
 Example entries:

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,8 @@
-// Hooks public exports
+export { useEditor } from './useEditor';
+export type { UseEditorOptions } from './useEditor';
+
+export { useToolbar } from './useToolbar';
+export type { UseToolbarResult } from './useToolbar';
+
+export { useHistory } from './useHistory';
+export type { UseHistoryResult } from './useHistory';

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -1,1 +1,134 @@
-// Placeholder for `useEditor` hook
+import { useEffect, useRef, useCallback } from 'react';
+import type { Editor } from '@tiptap/core';
+import { createEditor } from '@/core/engine';
+import { useEditorStore } from '@/core/store';
+
+export interface UseEditorOptions {
+  /** Initial / controlled HTML content */
+  value?: string;
+  /** Called when editor content changes */
+  onChange?: (html: string) => void;
+  /** Placeholder text when editor is empty */
+  placeholder?: string;
+  /** Disable editing */
+  readOnly?: boolean;
+  /** Called when editor gains focus */
+  onFocus?: () => void;
+  /** Called when editor loses focus */
+  onBlur?: () => void;
+}
+
+/**
+ * Primary hook — manages the Tiptap editor lifecycle and bridges
+ * it with the Zustand store.
+ *
+ * Responsibilities:
+ * - Create editor on mount, destroy on unmount
+ * - Sync `value` prop → Tiptap content (controlled component)
+ * - Forward Tiptap events → Zustand store + prop callbacks
+ * - Handle `readOnly` changes
+ */
+export function useEditor(options: UseEditorOptions = {}): Editor | null {
+  const { value = '', onChange, placeholder, readOnly = false, onFocus, onBlur } = options;
+
+  const editorRef = useRef<Editor | null>(null);
+  const isInternalUpdate = useRef(false);
+
+  const { setEditor, setContent, setFocused, updateActiveState } = useEditorStore.getState();
+
+  // ── Refresh active marks/nodes from editor state ──────────
+  const refreshActiveState = useCallback((editor: Editor) => {
+    const marks = new Set<string>();
+    const nodes = new Set<string>();
+    let headingLevel: number | null = null;
+
+    // Collect active marks
+    for (const mark of ['bold', 'italic', 'underline', 'strike', 'code', 'link']) {
+      if (editor.isActive(mark)) {
+        marks.add(mark);
+      }
+    }
+
+    // Collect active nodes
+    for (const node of ['bulletList', 'orderedList', 'blockquote', 'codeBlock']) {
+      if (editor.isActive(node)) {
+        nodes.add(node);
+      }
+    }
+
+    // Check headings (1–6)
+    for (let level = 1; level <= 6; level++) {
+      if (editor.isActive('heading', { level })) {
+        nodes.add('heading');
+        headingLevel = level;
+        break;
+      }
+    }
+
+    updateActiveState(marks, nodes, headingLevel);
+  }, [updateActiveState]);
+
+  // ── Create editor on mount ────────────────────────────────
+  useEffect(() => {
+    const editor = createEditor({
+      content: value,
+      editable: !readOnly,
+      placeholder,
+      onUpdate: (html) => {
+        isInternalUpdate.current = true;
+        setContent(html);
+        onChange?.(html);
+        // Refresh active state after content change
+        if (editorRef.current) {
+          refreshActiveState(editorRef.current);
+        }
+        isInternalUpdate.current = false;
+      },
+      onSelectionUpdate: () => {
+        if (editorRef.current) {
+          refreshActiveState(editorRef.current);
+        }
+      },
+      onFocus: () => {
+        setFocused(true);
+        onFocus?.();
+      },
+      onBlur: () => {
+        setFocused(false);
+        onBlur?.();
+      },
+    });
+
+    editorRef.current = editor;
+    setEditor(editor);
+
+    return () => {
+      editor.destroy();
+      editorRef.current = null;
+      setEditor(null);
+    };
+    // Only run on mount/unmount — props are synced via separate effects
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync controlled `value` prop → Tiptap ─────────────────
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || isInternalUpdate.current) return;
+
+    const currentHTML = editor.getHTML();
+    if (value !== currentHTML) {
+      editor.commands.setContent(value, { emitUpdate: false });
+    }
+  }, [value]);
+
+  // ── Sync `readOnly` prop ───────────────────────────────────
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.setEditable(!readOnly);
+    useEditorStore.getState().setReadOnly(readOnly);
+  }, [readOnly]);
+
+  return useEditorStore((s) => s.editor);
+}

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,1 +1,34 @@
-// Placeholder for `useHistory` hook
+import { useEditorStore } from '@/core/store';
+import { undo as undoCmd, redo as redoCmd } from '@/core/commands';
+
+export interface UseHistoryResult {
+  /** Execute undo */
+  undo: () => void;
+  /** Execute redo */
+  redo: () => void;
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Whether redo is available */
+  canRedo: boolean;
+}
+
+/**
+ * Lightweight hook for undo/redo state and actions.
+ *
+ * `canUndo` / `canRedo` re-evaluate whenever the editor reference
+ * or active marks change in the store (which happens on every
+ * transaction via `useEditor`'s selection update handler).
+ */
+export function useHistory(): UseHistoryResult {
+  const editor = useEditorStore((s) => s.editor);
+  // Subscribe to activeMarks to trigger re-renders on every transaction
+  // (activeMarks update acts as a proxy for "editor state changed")
+  useEditorStore((s) => s.activeMarks);
+
+  return {
+    undo: () => editor && undoCmd(editor),
+    redo: () => editor && redoCmd(editor),
+    canUndo: editor?.can().undo() ?? false,
+    canRedo: editor?.can().redo() ?? false,
+  };
+}

--- a/src/hooks/useToolbar.ts
+++ b/src/hooks/useToolbar.ts
@@ -1,1 +1,175 @@
-// Placeholder for `useToolbar` hook
+import { useMemo } from 'react';
+import type { Editor } from '@tiptap/core';
+import { useEditorStore } from '@/core/store';
+import {
+  toggleBold,
+  toggleItalic,
+  toggleUnderline,
+  toggleStrike,
+  setHeading,
+  toggleBulletList,
+  toggleOrderedList,
+  toggleBlockquote,
+  toggleCode,
+  toggleCodeBlock,
+  undo as undoCmd,
+  redo as redoCmd,
+} from '@/core/commands';
+import type { ToolbarItem, ToolbarItemType, ToolbarButtonConfig } from '@/types';
+
+// ── Platform detection for keyboard shortcut hints ──────────
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const mod = isMac ? '⌘' : 'Ctrl+';
+
+// ── Toolbar item metadata (static, no editor dependency) ────
+interface ToolbarItemMeta {
+  label: string;
+  shortcut?: string;
+}
+
+const TOOLBAR_META: Record<ToolbarItemType, ToolbarItemMeta> = {
+  bold: { label: 'Bold', shortcut: `${mod}B` },
+  italic: { label: 'Italic', shortcut: `${mod}I` },
+  underline: { label: 'Underline', shortcut: `${mod}U` },
+  strike: { label: 'Strikethrough', shortcut: `${mod}Shift+S` },
+  heading1: { label: 'Heading 1' },
+  heading2: { label: 'Heading 2' },
+  heading3: { label: 'Heading 3' },
+  heading4: { label: 'Heading 4' },
+  heading5: { label: 'Heading 5' },
+  heading6: { label: 'Heading 6' },
+  bulletList: { label: 'Bullet List' },
+  orderedList: { label: 'Ordered List' },
+  blockquote: { label: 'Blockquote' },
+  code: { label: 'Inline Code' },
+  codeBlock: { label: 'Code Block' },
+  link: { label: 'Link' },
+  image: { label: 'Image' },
+  undo: { label: 'Undo', shortcut: `${mod}Z` },
+  redo: { label: 'Redo', shortcut: isMac ? '⌘Shift+Z' : 'Ctrl+Y' },
+};
+
+// ── Action dispatcher ────────────────────────────────────────
+function getAction(id: ToolbarItemType, editor: Editor): () => void {
+  switch (id) {
+    case 'bold':
+      return () => toggleBold(editor);
+    case 'italic':
+      return () => toggleItalic(editor);
+    case 'underline':
+      return () => toggleUnderline(editor);
+    case 'strike':
+      return () => toggleStrike(editor);
+    case 'heading1':
+      return () => setHeading(editor, 1);
+    case 'heading2':
+      return () => setHeading(editor, 2);
+    case 'heading3':
+      return () => setHeading(editor, 3);
+    case 'heading4':
+      return () => setHeading(editor, 4);
+    case 'heading5':
+      return () => setHeading(editor, 5);
+    case 'heading6':
+      return () => setHeading(editor, 6);
+    case 'bulletList':
+      return () => toggleBulletList(editor);
+    case 'orderedList':
+      return () => toggleOrderedList(editor);
+    case 'blockquote':
+      return () => toggleBlockquote(editor);
+    case 'code':
+      return () => toggleCode(editor);
+    case 'codeBlock':
+      return () => toggleCodeBlock(editor);
+    case 'link':
+      // Link/image open their respective dialogs (Phase 11/12)
+      return () => useEditorStore.getState().setOpenDialog('link');
+    case 'image':
+      return () => useEditorStore.getState().setOpenDialog('image');
+    case 'undo':
+      return () => undoCmd(editor);
+    case 'redo':
+      return () => redoCmd(editor);
+  }
+}
+
+// ── Active state resolver ────────────────────────────────────
+function isItemActive(
+  id: ToolbarItemType,
+  activeMarks: Set<string>,
+  activeNodes: Set<string>,
+  headingLevel: number | null,
+): boolean {
+  switch (id) {
+    case 'bold':
+    case 'italic':
+    case 'underline':
+    case 'strike':
+    case 'code':
+    case 'link':
+      return activeMarks.has(id);
+    case 'heading1':
+      return headingLevel === 1;
+    case 'heading2':
+      return headingLevel === 2;
+    case 'heading3':
+      return headingLevel === 3;
+    case 'heading4':
+      return headingLevel === 4;
+    case 'heading5':
+      return headingLevel === 5;
+    case 'heading6':
+      return headingLevel === 6;
+    case 'bulletList':
+    case 'orderedList':
+    case 'blockquote':
+    case 'codeBlock':
+      return activeNodes.has(id);
+    default:
+      return false;
+  }
+}
+
+// ── Hook ─────────────────────────────────────────────────────
+
+export interface UseToolbarResult {
+  /** Resolved toolbar button configs (separators filtered to '|' strings) */
+  items: (ToolbarButtonConfig | '|')[];
+}
+
+/**
+ * Maps an array of `ToolbarItem` identifiers to resolved `ToolbarButtonConfig`
+ * objects with actions, active states, and labels.
+ *
+ * Icons are left as `null` for now — Phase 8 (Styles & Theming) or the
+ * Toolbar component (Phase 7) will supply actual icon components.
+ */
+export function useToolbar(toolbarItems: ToolbarItem[]): UseToolbarResult {
+  const editor = useEditorStore((s) => s.editor);
+  const readOnly = useEditorStore((s) => s.readOnly);
+  const activeMarks = useEditorStore((s) => s.activeMarks);
+  const activeNodes = useEditorStore((s) => s.activeNodes);
+  const headingLevel = useEditorStore((s) => s.headingLevel);
+
+  const items = useMemo(() => {
+    return toolbarItems.map((item): ToolbarButtonConfig | '|' => {
+      if (item === '|') return '|';
+
+      const meta = TOOLBAR_META[item];
+      const isDisabled = readOnly || !editor;
+
+      return {
+        id: item,
+        label: meta.label,
+        icon: null, // Icons will be provided by Toolbar component (Phase 7)
+        action: editor ? getAction(item, editor) : () => {},
+        isActive: isItemActive(item, activeMarks, activeNodes, headingLevel),
+        isDisabled,
+        shortcut: meta.shortcut,
+      };
+    });
+  }, [toolbarItems, editor, readOnly, activeMarks, activeNodes, headingLevel]);
+
+  return { items };
+}


### PR DESCRIPTION


- src/hooks/useEditor.ts: editor lifecycle, controlled value sync, active marks/nodes refresh
- src/hooks/useToolbar.ts: maps ToolbarItem[] to ToolbarButtonConfig[] with actions, active states, shortcuts
- src/hooks/useHistory.ts: undo/redo actions with canUndo/canRedo derived state
- src/hooks/index.ts: barrel re-exports with type exports
- Adapted to Tiptap v3 setContent API (SetContentOptions object instead of boolean)

# PR template

Please describe your changes and link any related issues.
