### PR TITLE
feat(phase-6): build editor shell components and full public API

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 5 / 25 phases complete | **20% done**
+**Overall:** 6 / 25 phases complete | **24% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -22,7 +22,7 @@
 | 3 | Type System Foundation | `Complete` | 2026-03-15 | 2026-03-15 | All interfaces, types, and constants defined |
 | 4 | Core Engine & Zustand Store | `Complete` | 2026-03-15 | 2026-03-15 | schema, engine, commands, store (Zustand), model, barrel |
 | 5 | React Hooks Layer | `Complete` | 2026-03-15 | 2026-03-15 | useEditor, useToolbar, useHistory; Tiptap v3 setContent API |
-| 6 | Core Components: Editor Shell | `Not Started` | — | — | |
+| 6 | Core Components: Editor Shell | `Complete` | 2026-03-15 | 2026-03-15 | ContentEditable, Parser, Serializer, EditorProvider, EditorWrapper, RichTextEditor, full public API |
 | 7 | Toolbar System | `Not Started` | — | — | |
 | 8 | Styles & Theming | `Not Started` | — | — | |
 | 9 | Plugins: Text Formatting & Headings | `Not Started` | — | — | |
@@ -1038,10 +1038,10 @@ export { useHistory } from './useHistory';
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-6-editor-shell` |
 | **Blocked by** | Phase 5 |
 | **Deliverables** | `ContentEditable.tsx`, `Parser.ts`, `Serializer.ts`, `EditorProvider.tsx`, `EditorWrapper.tsx`, `RichTextEditor.tsx`, index files |
 
@@ -1177,9 +1177,9 @@ export function RichTextEditor(props: RichTextEditorProps) {
 
 ### Checkpoint
 
-- [ ] `<RichTextEditor value="" onChange={console.log} />` renders without errors
-- [ ] Typing in the content area triggers `onChange` with HTML
-- [ ] `yarn build` succeeds
+- [x] `<RichTextEditor value="" onChange={console.log} />` renders without errors
+- [x] Typing in the content area triggers `onChange` with HTML
+- [x] `yarn build` succeeds
 
 ---
 
@@ -2974,6 +2974,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 3 | Defined all TypeScript interfaces: editor types, toolbar types, plugin types, barrel index | No deviations; import graph is acyclic (editor→toolbar, plugin→toolbar) |
 | 2026-03-15 | 4 | Built core engine: schema.ts (StarterKit), engine.ts (editor factory), commands.ts (15 commands), store.ts (Zustand), model.ts (HTML↔JSON), barrel | Used insertContent for image cmd (Image ext not yet loaded); fixed no-undef ESLint rule for TS files; added React type imports to Phase 3 files |
 | 2026-03-15 | 5 | Built 3 custom React hooks: useEditor (lifecycle, controlled value sync, active state), useToolbar (item→config mapping, actions, active states), useHistory (undo/redo with canUndo/canRedo) | Tiptap v3 changed setContent 2nd param from boolean to SetContentOptions object; icons deferred to Phase 7 Toolbar component |
+| 2026-03-15 | 6 | Built editor shell: ContentEditable (EditorContent wrapper), Parser/Serializer (JSON↔HTML), EditorProvider (lifecycle bridge), EditorWrapper (composition), RichTextEditor (public API). Populated src/index.ts with full public API exports | Used @tiptap/core for generateHTML/generateJSON (not @tiptap/html); Toolbar stub until Phase 7; bundle now 13KB ESM |
 
 <!--
 Example entries:

--- a/src/components/Content/ContentEditable.tsx
+++ b/src/components/Content/ContentEditable.tsx
@@ -1,1 +1,45 @@
-// Placeholder for the editable content area component
+import { EditorContent } from '@tiptap/react';
+import type { Editor } from '@tiptap/core';
+
+export interface ContentEditableProps {
+  /** The Tiptap editor instance */
+  editor: Editor | null;
+  /** Minimum height of the editable area */
+  minHeight?: string | number;
+  /** Maximum height of the editable area (enables scrolling) */
+  maxHeight?: string | number;
+  /** Placeholder text shown when editor is empty */
+  placeholder?: string;
+  /** Additional CSS class name */
+  className?: string;
+}
+
+/**
+ * Renders Tiptap's EditorContent with size constraints and placeholder.
+ *
+ * The placeholder is rendered via a `data-placeholder` attribute and
+ * CSS `:empty::before` pseudo-element (styled in Phase 8).
+ */
+export function ContentEditable({
+  editor,
+  minHeight,
+  maxHeight,
+  placeholder,
+  className,
+}: ContentEditableProps) {
+  const style: React.CSSProperties = {
+    minHeight: typeof minHeight === 'number' ? `${minHeight}px` : minHeight,
+    maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight,
+    overflowY: maxHeight ? 'auto' : undefined,
+  };
+
+  return (
+    <div
+      className={className}
+      style={style}
+      data-placeholder={placeholder}
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
+}

--- a/src/components/Content/Parser.ts
+++ b/src/components/Content/Parser.ts
@@ -1,1 +1,10 @@
-// Placeholder for parser (HTML -> state)
+import { generateJSON } from '@tiptap/core';
+import type { JSONContent } from '@tiptap/core';
+import { createExtensions } from '@/core/schema';
+
+/**
+ * Parse an HTML string into a Tiptap JSON document.
+ */
+export function parseHTML(html: string): JSONContent {
+  return generateJSON(html, createExtensions());
+}

--- a/src/components/Content/Serializer.ts
+++ b/src/components/Content/Serializer.ts
@@ -1,1 +1,10 @@
-// Placeholder for serializer (state -> HTML)
+import { generateHTML } from '@tiptap/core';
+import type { JSONContent } from '@tiptap/core';
+import { createExtensions } from '@/core/schema';
+
+/**
+ * Serialize a Tiptap JSON document to an HTML string.
+ */
+export function serializeHTML(doc: JSONContent): string {
+  return generateHTML(doc, createExtensions());
+}

--- a/src/components/Content/index.ts
+++ b/src/components/Content/index.ts
@@ -1,1 +1,5 @@
-// Content public exports
+export { ContentEditable } from './ContentEditable';
+export type { ContentEditableProps } from './ContentEditable';
+
+export { parseHTML } from './Parser';
+export { serializeHTML } from './Serializer';

--- a/src/components/Editor/EditorProvider.tsx
+++ b/src/components/Editor/EditorProvider.tsx
@@ -1,1 +1,59 @@
-// Placeholder for `EditorProvider` (context)
+import { useEffect } from 'react';
+import { useEditor } from '@/hooks/useEditor';
+import { useEditorStore } from '@/core/store';
+import type { Theme } from '@/types';
+
+export interface EditorProviderProps {
+  /** Controlled HTML content */
+  value?: string;
+  /** Called when content changes */
+  onChange?: (value: string) => void;
+  /** Disable editing */
+  readOnly?: boolean;
+  /** Theme: 'light' or 'dark' */
+  theme?: Theme;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Called when editor gains focus */
+  onFocus?: () => void;
+  /** Called when editor loses focus */
+  onBlur?: () => void;
+  /** Children to render */
+  children: React.ReactNode;
+}
+
+/**
+ * Lifecycle component that bridges props to the Zustand store.
+ *
+ * Initializes the Tiptap editor via `useEditor` and syncs
+ * `theme` and `readOnly` props to the store. Does NOT use
+ * React Context — the Zustand store IS the context.
+ */
+export function EditorProvider({
+  value,
+  onChange,
+  readOnly = false,
+  theme = 'light',
+  placeholder,
+  onFocus,
+  onBlur,
+  children,
+}: EditorProviderProps) {
+  // Initialize and manage the Tiptap editor lifecycle
+  useEditor({ value, onChange, placeholder, readOnly, onFocus, onBlur });
+
+  const setTheme = useEditorStore((s) => s.setTheme);
+  const setReadOnly = useEditorStore((s) => s.setReadOnly);
+
+  // Sync theme prop → store
+  useEffect(() => {
+    setTheme(theme);
+  }, [theme, setTheme]);
+
+  // Sync readOnly prop → store
+  useEffect(() => {
+    setReadOnly(readOnly);
+  }, [readOnly, setReadOnly]);
+
+  return <>{children}</>;
+}

--- a/src/components/Editor/EditorWrapper.tsx
+++ b/src/components/Editor/EditorWrapper.tsx
@@ -1,1 +1,65 @@
-// Placeholder for `EditorWrapper` component
+import { useEditorStore } from '@/core/store';
+import { ContentEditable } from '@/components/Content';
+import type { ToolbarItem } from '@/types';
+
+export interface EditorWrapperProps {
+  /** Toolbar items configuration */
+  toolbar: ToolbarItem[];
+  /** Placeholder text when editor is empty */
+  placeholder?: string;
+  /** Minimum height of the editable area */
+  minHeight?: string | number;
+  /** Maximum height of the editable area */
+  maxHeight?: string | number;
+  /** Additional CSS class for the outer wrapper */
+  className?: string;
+  /** Inline styles for the outer wrapper */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Composes Toolbar + ContentEditable vertically.
+ *
+ * Applies `data-theme` attribute for CSS theming and conditionally
+ * hides the toolbar when `readOnly` is true.
+ *
+ * NOTE: Toolbar component is a stub until Phase 7. Dialogs are
+ * added in Phases 11–12.
+ */
+export function EditorWrapper({
+  toolbar: _toolbar,
+  placeholder,
+  minHeight,
+  maxHeight,
+  className,
+  style,
+}: EditorWrapperProps) {
+  const editor = useEditorStore((s) => s.editor);
+  const theme = useEditorStore((s) => s.theme);
+  const readOnly = useEditorStore((s) => s.readOnly);
+
+  return (
+    <div
+      className={className}
+      style={style}
+      data-theme={theme}
+      data-readonly={readOnly || undefined}
+    >
+      {/* Toolbar will be rendered here in Phase 7 */}
+      {!readOnly && (
+        <div role="toolbar" aria-label="Text formatting" aria-orientation="horizontal">
+          {/* Phase 7: <Toolbar items={toolbarItems} /> */}
+        </div>
+      )}
+
+      <ContentEditable
+        editor={editor}
+        minHeight={minHeight}
+        maxHeight={maxHeight}
+        placeholder={placeholder}
+      />
+
+      {/* Dialogs rendered here in Phases 11–12 */}
+    </div>
+  );
+}

--- a/src/components/Editor/RichTextEditor.tsx
+++ b/src/components/Editor/RichTextEditor.tsx
@@ -1,1 +1,55 @@
-// Placeholder for `RichTextEditor` React component
+import type { RichTextEditorProps } from '@/types';
+import { DEFAULT_TOOLBAR } from '@/types';
+import { EditorProvider } from './EditorProvider';
+import { EditorWrapper } from './EditorWrapper';
+
+/**
+ * The public API component — the one consumers import.
+ *
+ * ```tsx
+ * import { RichTextEditor } from 'rich-text-editor-ndevu';
+ *
+ * <RichTextEditor
+ *   value={html}
+ *   onChange={setHtml}
+ *   theme="dark"
+ * />
+ * ```
+ */
+export function RichTextEditor(props: RichTextEditorProps) {
+  const {
+    value = '',
+    onChange,
+    placeholder = 'Write something...',
+    readOnly = false,
+    toolbar = DEFAULT_TOOLBAR,
+    theme = 'light',
+    minHeight = '200px',
+    maxHeight,
+    className,
+    style,
+    onFocus,
+    onBlur,
+  } = props;
+
+  return (
+    <EditorProvider
+      value={value}
+      onChange={onChange}
+      readOnly={readOnly}
+      theme={theme}
+      placeholder={placeholder}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
+      <EditorWrapper
+        toolbar={toolbar}
+        placeholder={placeholder}
+        minHeight={minHeight}
+        maxHeight={maxHeight}
+        className={className}
+        style={style}
+      />
+    </EditorProvider>
+  );
+}

--- a/src/components/Editor/index.ts
+++ b/src/components/Editor/index.ts
@@ -1,1 +1,5 @@
-// Editor public exports
+export { RichTextEditor } from './RichTextEditor';
+export { EditorProvider } from './EditorProvider';
+export type { EditorProviderProps } from './EditorProvider';
+export { EditorWrapper } from './EditorWrapper';
+export type { EditorWrapperProps } from './EditorWrapper';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,54 @@
-// Public API entry point — exports will be added as components are implemented.
-export {};
+// ── Public API ───────────────────────────────
+
+// Main component
+export { RichTextEditor } from './components/Editor';
+
+// Types
+export type {
+  RichTextEditorProps,
+  Theme,
+  DialogType,
+  EditorState,
+  EditorActions,
+  EditorConfig,
+} from './types';
+export type {
+  ToolbarItemType,
+  ToolbarSeparator,
+  ToolbarItem,
+  ToolbarButtonConfig,
+  ToolbarGroupConfig,
+} from './types';
+export { DEFAULT_TOOLBAR } from './types';
+
+// Hooks (advanced usage)
+export { useEditor } from './hooks';
+export type { UseEditorOptions } from './hooks';
+export { useToolbar } from './hooks';
+export type { UseToolbarResult } from './hooks';
+export { useHistory } from './hooks';
+export type { UseHistoryResult } from './hooks';
+
+// Core utilities (advanced usage)
+export { useEditorStore } from './core';
+export type { EditorStore } from './core';
+export { createEditor, createExtensions } from './core';
+export type { CreateEditorOptions } from './core';
+export {
+  toggleBold,
+  toggleItalic,
+  toggleUnderline,
+  toggleStrike,
+  setHeading,
+  toggleBulletList,
+  toggleOrderedList,
+  toggleBlockquote,
+  toggleCode,
+  toggleCodeBlock,
+  insertLink,
+  removeLink,
+  insertImage,
+  undo,
+  redo,
+} from './core';
+export { toHTML, fromHTML, createEmptyDoc, isContentEmpty } from './core';


### PR DESCRIPTION
- src/components/Content/ContentEditable.tsx: Tiptap EditorContent wrapper with size constraints
- src/components/Content/Parser.ts: HTML → JSON via generateJSON (@tiptap/core)
- src/components/Content/Serializer.ts: JSON → HTML via generateHTML (@tiptap/core)
- src/components/Content/index.ts: barrel re-exports
- src/components/Editor/EditorProvider.tsx: lifecycle bridge (props → Zustand store)
- src/components/Editor/EditorWrapper.tsx: composes toolbar + content area with theme
- src/components/Editor/RichTextEditor.tsx: public API component with default props
- src/components/Editor/index.ts: barrel re-exports
- src/index.ts: full public API (component, types, hooks, core utilities)

# PR template

Please describe your changes and link any related issues.
