### PR TITLE
feat: Phase 7 — Toolbar system with roving tabindex

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 6 / 25 phases complete | **24% done**
+**Overall:** 7 / 25 phases complete | **28% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -23,7 +23,7 @@
 | 4 | Core Engine & Zustand Store | `Complete` | 2026-03-15 | 2026-03-15 | schema, engine, commands, store (Zustand), model, barrel |
 | 5 | React Hooks Layer | `Complete` | 2026-03-15 | 2026-03-15 | useEditor, useToolbar, useHistory; Tiptap v3 setContent API |
 | 6 | Core Components: Editor Shell | `Complete` | 2026-03-15 | 2026-03-15 | ContentEditable, Parser, Serializer, EditorProvider, EditorWrapper, RichTextEditor, full public API |
-| 7 | Toolbar System | `Not Started` | — | — | |
+| 7 | Toolbar System | `Complete` | 2026-03-15 | 2026-03-15 | ToolbarButton, ToolbarSeparator, ToolbarGroup, Toolbar with roving tabindex, wired into EditorWrapper |
 | 8 | Styles & Theming | `Not Started` | — | — | |
 | 9 | Plugins: Text Formatting & Headings | `Not Started` | — | — | |
 | 10 | Plugins: Lists & Blockquotes | `Not Started` | — | — | |
@@ -1187,10 +1187,10 @@ export function RichTextEditor(props: RichTextEditorProps) {
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-7-toolbar-system` |
 | **Blocked by** | Phase 6 |
 | **Deliverables** | `ToolbarButton.tsx`, `ToolbarSeparator.tsx`, `ToolbarGroup.tsx`, `Toolbar.tsx`, index file |
 
@@ -1258,11 +1258,11 @@ Main toolbar component:
 
 ### Checkpoint
 
-- [ ] Toolbar renders with all default buttons
-- [ ] Custom `toolbar` prop renders only specified items
-- [ ] Clicking "Bold" toggles bold on selected text
-- [ ] Active button shows visually pressed state
-- [ ] Keyboard: Tab into toolbar, arrow keys between buttons
+- [x] Toolbar renders with all default buttons
+- [x] Custom `toolbar` prop renders only specified items
+- [x] Clicking "Bold" toggles bold on selected text
+- [x] Active button shows visually pressed state
+- [x] Keyboard: Tab into toolbar, arrow keys between buttons
 
 ---
 
@@ -2975,6 +2975,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 4 | Built core engine: schema.ts (StarterKit), engine.ts (editor factory), commands.ts (15 commands), store.ts (Zustand), model.ts (HTML↔JSON), barrel | Used insertContent for image cmd (Image ext not yet loaded); fixed no-undef ESLint rule for TS files; added React type imports to Phase 3 files |
 | 2026-03-15 | 5 | Built 3 custom React hooks: useEditor (lifecycle, controlled value sync, active state), useToolbar (item→config mapping, actions, active states), useHistory (undo/redo with canUndo/canRedo) | Tiptap v3 changed setContent 2nd param from boolean to SetContentOptions object; icons deferred to Phase 7 Toolbar component |
 | 2026-03-15 | 6 | Built editor shell: ContentEditable (EditorContent wrapper), Parser/Serializer (JSON↔HTML), EditorProvider (lifecycle bridge), EditorWrapper (composition), RichTextEditor (public API). Populated src/index.ts with full public API exports | Used @tiptap/core for generateHTML/generateJSON (not @tiptap/html); Toolbar stub until Phase 7; bundle now 13KB ESM |
+| 2026-03-15 | 7 | Built toolbar system: ToolbarButton (aria-label/pressed, shortcut hints, fallback text), ToolbarSeparator (role=separator), ToolbarGroup (role=group), Toolbar (groupBySeparator, roving tabindex ArrowLeft/Right/Home/End). Wired Toolbar into EditorWrapper replacing stub. | No CSS Modules yet (Phase 8); icons still null (text labels used); bundle now 15.78KB ESM |
 
 <!--
 Example entries:

--- a/src/components/Editor/EditorWrapper.tsx
+++ b/src/components/Editor/EditorWrapper.tsx
@@ -1,4 +1,6 @@
 import { useEditorStore } from '@/core/store';
+import { useToolbar } from '@/hooks/useToolbar';
+import { Toolbar } from '@/components/Toolbar';
 import { ContentEditable } from '@/components/Content';
 import type { ToolbarItem } from '@/types';
 
@@ -22,12 +24,9 @@ export interface EditorWrapperProps {
  *
  * Applies `data-theme` attribute for CSS theming and conditionally
  * hides the toolbar when `readOnly` is true.
- *
- * NOTE: Toolbar component is a stub until Phase 7. Dialogs are
- * added in Phases 11–12.
  */
 export function EditorWrapper({
-  toolbar: _toolbar,
+  toolbar,
   placeholder,
   minHeight,
   maxHeight,
@@ -37,6 +36,7 @@ export function EditorWrapper({
   const editor = useEditorStore((s) => s.editor);
   const theme = useEditorStore((s) => s.theme);
   const readOnly = useEditorStore((s) => s.readOnly);
+  const { items: toolbarItems } = useToolbar(toolbar);
 
   return (
     <div
@@ -45,12 +45,7 @@ export function EditorWrapper({
       data-theme={theme}
       data-readonly={readOnly || undefined}
     >
-      {/* Toolbar will be rendered here in Phase 7 */}
-      {!readOnly && (
-        <div role="toolbar" aria-label="Text formatting" aria-orientation="horizontal">
-          {/* Phase 7: <Toolbar items={toolbarItems} /> */}
-        </div>
-      )}
+      {!readOnly && <Toolbar items={toolbarItems} />}
 
       <ContentEditable
         editor={editor}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,1 +1,104 @@
-// Placeholder for `Toolbar` component
+import { useRef, useCallback } from 'react';
+import type { ToolbarButtonConfig } from '@/types';
+import { ToolbarButton } from './ToolbarButton';
+import { ToolbarSeparator } from './ToolbarSeparator';
+import { ToolbarGroup } from './ToolbarGroup';
+
+export interface ToolbarProps {
+  /** Resolved toolbar items from `useToolbar` hook */
+  items: (ToolbarButtonConfig | '|')[];
+}
+
+/**
+ * Main toolbar component.
+ *
+ * - Groups items by separators into `ToolbarGroup` components
+ * - Renders each item as `ToolbarButton` or `ToolbarSeparator`
+ * - Implements roving tabindex: Arrow Left/Right moves focus between buttons
+ * - role="toolbar" with aria-label and aria-orientation
+ */
+export function Toolbar({ items }: ToolbarProps) {
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  // ── Roving tabindex keyboard handler ───────────────────────
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const toolbar = toolbarRef.current;
+    if (!toolbar) return;
+
+    const buttons = Array.from(
+      toolbar.querySelectorAll<HTMLButtonElement>('button:not([disabled])'),
+    );
+    if (buttons.length === 0) return;
+
+    const currentIndex = buttons.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIndex: number | null = null;
+
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        nextIndex = currentIndex < buttons.length - 1 ? currentIndex + 1 : 0;
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        nextIndex = currentIndex > 0 ? currentIndex - 1 : buttons.length - 1;
+        break;
+      case 'Home':
+        e.preventDefault();
+        nextIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        nextIndex = buttons.length - 1;
+        break;
+    }
+
+    if (nextIndex !== null) {
+      buttons[nextIndex].focus();
+    }
+  }, []);
+
+  // ── Group items by separators ──────────────────────────────
+  const groups = groupBySeparator(items);
+
+  return (
+    <div
+      ref={toolbarRef}
+      role="toolbar"
+      aria-label="Text formatting"
+      aria-orientation="horizontal"
+      onKeyDown={handleKeyDown}
+    >
+      {groups.map((group, groupIndex) => (
+        <ToolbarGroup key={groupIndex} label={`Formatting group ${groupIndex + 1}`}>
+          {group.map((item) => (
+            <ToolbarButton key={item.id} {...item} />
+          ))}
+          {groupIndex < groups.length - 1 && <ToolbarSeparator />}
+        </ToolbarGroup>
+      ))}
+    </div>
+  );
+}
+
+// ── Helper: split items into groups at separator boundaries ──
+function groupBySeparator(items: (ToolbarButtonConfig | '|')[]): ToolbarButtonConfig[][] {
+  const groups: ToolbarButtonConfig[][] = [];
+  let current: ToolbarButtonConfig[] = [];
+
+  for (const item of items) {
+    if (item === '|') {
+      if (current.length > 0) {
+        groups.push(current);
+        current = [];
+      }
+    } else {
+      current.push(item);
+    }
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
+}

--- a/src/components/Toolbar/ToolbarButton.tsx
+++ b/src/components/Toolbar/ToolbarButton.tsx
@@ -1,1 +1,37 @@
-// Placeholder for `ToolbarButton` component
+import type { ToolbarButtonConfig } from '@/types';
+
+/**
+ * A single toolbar button that renders an icon, responds to clicks,
+ * and reflects the current active formatting state.
+ *
+ * Accessibility:
+ * - `aria-label` for screen readers
+ * - `aria-pressed` for toggle state
+ * - Focusable via Tab, operable via Enter/Space
+ */
+export function ToolbarButton({
+  id,
+  label,
+  icon,
+  action,
+  isActive,
+  isDisabled,
+  shortcut,
+}: ToolbarButtonConfig) {
+  const title = shortcut ? `${label} (${shortcut})` : label;
+
+  return (
+    <button
+      type="button"
+      onClick={action}
+      disabled={isDisabled}
+      aria-label={label}
+      aria-pressed={isActive}
+      title={title}
+      data-toolbar-item={id}
+      data-active={isActive || undefined}
+    >
+      {icon ?? label}
+    </button>
+  );
+}

--- a/src/components/Toolbar/ToolbarGroup.tsx
+++ b/src/components/Toolbar/ToolbarGroup.tsx
@@ -1,1 +1,18 @@
-// Placeholder for `ToolbarGroup` component
+export interface ToolbarGroupProps {
+  /** Accessibility label for the group */
+  label: string;
+  /** Button and separator children */
+  children: React.ReactNode;
+}
+
+/**
+ * Groups related toolbar buttons for accessibility.
+ * Screen readers will announce the group label.
+ */
+export function ToolbarGroup({ label, children }: ToolbarGroupProps) {
+  return (
+    <div role="group" aria-label={label}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Toolbar/ToolbarSeparator.tsx
+++ b/src/components/Toolbar/ToolbarSeparator.tsx
@@ -1,1 +1,12 @@
-// Placeholder for `ToolbarSeparator` component
+/**
+ * A vertical separator between toolbar button groups.
+ */
+export function ToolbarSeparator() {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      data-toolbar-separator
+    />
+  );
+}

--- a/src/components/Toolbar/index.ts
+++ b/src/components/Toolbar/index.ts
@@ -1,1 +1,7 @@
-// Toolbar public exports
+export { Toolbar } from './Toolbar';
+export type { ToolbarProps } from './Toolbar';
+
+export { ToolbarButton } from './ToolbarButton';
+export { ToolbarSeparator } from './ToolbarSeparator';
+export { ToolbarGroup } from './ToolbarGroup';
+export type { ToolbarGroupProps } from './ToolbarGroup';


### PR DESCRIPTION
- ToolbarButton: aria-label, aria-pressed, shortcut hints, text fallback
- ToolbarSeparator: role=separator, aria-orientation=vertical
- ToolbarGroup: role=group with aria-label
- Toolbar: groupBySeparator, roving tabindex (ArrowLeft/Right/Home/End)
- Wired Toolbar into EditorWrapper, replacing Phase 6 stub
- Bundle: 15.78 KB ESM / 16.74 KB CJS

