### PR TITLE
feat: Phase 8 — Styles & theming with light/dark CSS tokens

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 7 / 25 phases complete | **28% done**
+**Overall:** 8 / 25 phases complete | **32% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -24,7 +24,7 @@
 | 5 | React Hooks Layer | `Complete` | 2026-03-15 | 2026-03-15 | useEditor, useToolbar, useHistory; Tiptap v3 setContent API |
 | 6 | Core Components: Editor Shell | `Complete` | 2026-03-15 | 2026-03-15 | ContentEditable, Parser, Serializer, EditorProvider, EditorWrapper, RichTextEditor, full public API |
 | 7 | Toolbar System | `Complete` | 2026-03-15 | 2026-03-15 | ToolbarButton, ToolbarSeparator, ToolbarGroup, Toolbar with roving tabindex, wired into EditorWrapper |
-| 8 | Styles & Theming | `Not Started` | — | — | |
+| 8 | Styles & Theming | `Complete` | 2026-03-15 | 2026-03-15 | 32 CSS tokens per theme, .rte-* BEM classes, prose typography, 7.40 KB CSS bundle |
 | 9 | Plugins: Text Formatting & Headings | `Not Started` | — | — | |
 | 10 | Plugins: Lists & Blockquotes | `Not Started` | — | — | |
 | 11 | Plugins: Links & Link Dialog | `Not Started` | — | — | |
@@ -1270,10 +1270,10 @@ Main toolbar component:
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `chore/phase-8-styles-theming` |
 | **Blocked by** | Phase 7 |
 | **Deliverables** | `theme-light.css`, `theme-dark.css`, `editor.css`, `toolbar.css`, `index.css` |
 
@@ -1364,11 +1364,11 @@ This file is the one included in the built package so consumers get themes autom
 
 ### Checkpoint
 
-- [ ] Editor renders with polished light theme
-- [ ] `theme="dark"` switches all colors correctly
-- [ ] Toolbar buttons have hover, active, pressed, disabled states
-- [ ] Content typography (headings, lists, quotes, code) looks professional
-- [ ] No style leakage outside the editor wrapper
+- [x] Editor renders with polished light theme
+- [x] `theme="dark"` switches all colors correctly
+- [x] Toolbar buttons have hover, active, pressed, disabled states
+- [x] Content typography (headings, lists, quotes, code) looks professional
+- [x] No style leakage outside the editor wrapper
 
 ---
 
@@ -2976,6 +2976,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 5 | Built 3 custom React hooks: useEditor (lifecycle, controlled value sync, active state), useToolbar (item→config mapping, actions, active states), useHistory (undo/redo with canUndo/canRedo) | Tiptap v3 changed setContent 2nd param from boolean to SetContentOptions object; icons deferred to Phase 7 Toolbar component |
 | 2026-03-15 | 6 | Built editor shell: ContentEditable (EditorContent wrapper), Parser/Serializer (JSON↔HTML), EditorProvider (lifecycle bridge), EditorWrapper (composition), RichTextEditor (public API). Populated src/index.ts with full public API exports | Used @tiptap/core for generateHTML/generateJSON (not @tiptap/html); Toolbar stub until Phase 7; bundle now 13KB ESM |
 | 2026-03-15 | 7 | Built toolbar system: ToolbarButton (aria-label/pressed, shortcut hints, fallback text), ToolbarSeparator (role=separator), ToolbarGroup (role=group), Toolbar (groupBySeparator, roving tabindex ArrowLeft/Right/Home/End). Wired Toolbar into EditorWrapper replacing stub. | No CSS Modules yet (Phase 8); icons still null (text labels used); bundle now 15.78KB ESM |
+| 2026-03-15 | 8 | Built styles & theming: theme-light.css + theme-dark.css (32 tokens each), editor.css (wrapper, focus ring, prose typography for headings/lists/blockquote/code/links/images/hr), toolbar.css (button hover/active/pressed/disabled/focus-visible, separator, group), index.css master import. Wired .rte-* classes into all components. CSS bundled via import in src/index.ts. | Used .rte-* BEM-style prefix instead of CSS Modules (better for library consumers); CSS output 7.40 KB |
 
 <!--
 Example entries:

--- a/src/components/Editor/EditorWrapper.tsx
+++ b/src/components/Editor/EditorWrapper.tsx
@@ -38,9 +38,11 @@ export function EditorWrapper({
   const readOnly = useEditorStore((s) => s.readOnly);
   const { items: toolbarItems } = useToolbar(toolbar);
 
+  const wrapperClass = ['rte-editor', className].filter(Boolean).join(' ');
+
   return (
     <div
-      className={className}
+      className={wrapperClass}
       style={style}
       data-theme={theme}
       data-readonly={readOnly || undefined}
@@ -52,6 +54,7 @@ export function EditorWrapper({
         minHeight={minHeight}
         maxHeight={maxHeight}
         placeholder={placeholder}
+        className="rte-content"
       />
 
       {/* Dialogs rendered here in Phases 11–12 */}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -63,6 +63,7 @@ export function Toolbar({ items }: ToolbarProps) {
   return (
     <div
       ref={toolbarRef}
+      className="rte-toolbar"
       role="toolbar"
       aria-label="Text formatting"
       aria-orientation="horizontal"

--- a/src/components/Toolbar/ToolbarButton.tsx
+++ b/src/components/Toolbar/ToolbarButton.tsx
@@ -23,6 +23,7 @@ export function ToolbarButton({
   return (
     <button
       type="button"
+      className="rte-toolbar__button"
       onClick={action}
       disabled={isDisabled}
       aria-label={label}

--- a/src/components/Toolbar/ToolbarGroup.tsx
+++ b/src/components/Toolbar/ToolbarGroup.tsx
@@ -11,7 +11,7 @@ export interface ToolbarGroupProps {
  */
 export function ToolbarGroup({ label, children }: ToolbarGroupProps) {
   return (
-    <div role="group" aria-label={label}>
+    <div className="rte-toolbar__group" role="group" aria-label={label}>
       {children}
     </div>
   );

--- a/src/components/Toolbar/ToolbarSeparator.tsx
+++ b/src/components/Toolbar/ToolbarSeparator.tsx
@@ -4,6 +4,7 @@
 export function ToolbarSeparator() {
   return (
     <div
+      className="rte-toolbar__separator"
       role="separator"
       aria-orientation="vertical"
       data-toolbar-separator

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// ── Styles (bundled to dist/index.css by tsup) ──────────
+import './styles/index.css';
+
 // ── Public API ───────────────────────────────
 
 // Main component

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -1,1 +1,196 @@
-/* Placeholder editor styles */
+/**
+ * Editor component styles.
+ *
+ * `.rte-editor` — outer wrapper (border, radius, theme surface)
+ * `.rte-content` — editable area (padding, min/max height, typography)
+ *
+ * Prose typography targets the Tiptap ProseMirror content inside
+ * `.rte-content .tiptap` to keep specificity predictable.
+ */
+
+/* ── Editor wrapper ────────────────────────────────────── */
+.rte-editor {
+  position: relative;
+  border: 1px solid var(--rte-border);
+  border-radius: var(--rte-radius);
+  background: var(--rte-bg);
+  color: var(--rte-text);
+  font-family: var(--rte-font-family);
+  font-size: var(--rte-font-size);
+  line-height: var(--rte-line-height);
+  overflow: hidden;
+  box-shadow: var(--rte-shadow);
+}
+
+/* Read-only mode */
+.rte-editor[data-readonly] {
+  cursor: default;
+}
+
+/* ── Content area (wraps Tiptap's EditorContent) ───────── */
+.rte-content {
+  padding: 16px 20px;
+}
+
+/* Focus ring when the Tiptap editor is focused */
+.rte-editor:focus-within {
+  border-color: var(--rte-accent);
+  box-shadow:
+    var(--rte-shadow),
+    0 0 0 3px var(--rte-focus-ring);
+}
+
+/* Read-only removes focus ring */
+.rte-editor[data-readonly]:focus-within {
+  border-color: var(--rte-border);
+  box-shadow: var(--rte-shadow);
+}
+
+/* ── Placeholder ───────────────────────────────────────── */
+.rte-content .tiptap p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+  color: var(--rte-placeholder);
+}
+
+/* ──────────────────────────────────────────────────────── */
+/*  Prose typography — targets `.rte-content .tiptap`       */
+/* ──────────────────────────────────────────────────────── */
+.rte-content .tiptap {
+  outline: none;
+}
+
+/* ── Paragraphs ────────────────────────────────────────── */
+.rte-content .tiptap p {
+  margin: 0 0 0.75em;
+}
+
+.rte-content .tiptap p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Headings ──────────────────────────────────────────── */
+.rte-content .tiptap h1,
+.rte-content .tiptap h2,
+.rte-content .tiptap h3,
+.rte-content .tiptap h4,
+.rte-content .tiptap h5,
+.rte-content .tiptap h6 {
+  margin: 1.25em 0 0.5em;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--rte-text);
+}
+
+.rte-content .tiptap h1:first-child,
+.rte-content .tiptap h2:first-child,
+.rte-content .tiptap h3:first-child {
+  margin-top: 0;
+}
+
+.rte-content .tiptap h1 { font-size: 2em; }
+.rte-content .tiptap h2 { font-size: 1.5em; }
+.rte-content .tiptap h3 { font-size: 1.25em; }
+.rte-content .tiptap h4 { font-size: 1.1em; }
+.rte-content .tiptap h5 { font-size: 1em; }
+.rte-content .tiptap h6 { font-size: 0.9em; color: var(--rte-text-muted); }
+
+/* ── Lists ─────────────────────────────────────────────── */
+.rte-content .tiptap ul,
+.rte-content .tiptap ol {
+  margin: 0 0 0.75em;
+  padding-left: 1.5em;
+}
+
+.rte-content .tiptap ul { list-style-type: disc; }
+.rte-content .tiptap ol { list-style-type: decimal; }
+
+/* Nested list markers */
+.rte-content .tiptap ul ul { list-style-type: circle; }
+.rte-content .tiptap ul ul ul { list-style-type: square; }
+.rte-content .tiptap ol ol { list-style-type: lower-alpha; }
+.rte-content .tiptap ol ol ol { list-style-type: lower-roman; }
+
+.rte-content .tiptap li {
+  margin-bottom: 0.25em;
+}
+
+.rte-content .tiptap li p {
+  margin: 0;
+}
+
+/* ── Blockquote ────────────────────────────────────────── */
+.rte-content .tiptap blockquote {
+  margin: 0.75em 0;
+  padding: 0.5em 0 0.5em 1em;
+  border-left: 3px solid var(--rte-blockquote-border);
+  color: var(--rte-blockquote-text);
+  font-style: italic;
+}
+
+.rte-content .tiptap blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Inline code ───────────────────────────────────────── */
+.rte-content .tiptap code {
+  padding: 0.15em 0.35em;
+  border-radius: var(--rte-radius-sm);
+  background: var(--rte-code-bg);
+  color: var(--rte-code-text);
+  font-family: var(--rte-font-mono);
+  font-size: 0.9em;
+}
+
+/* ── Code block ────────────────────────────────────────── */
+.rte-content .tiptap pre {
+  margin: 0.75em 0;
+  padding: 1em;
+  border-radius: var(--rte-radius-sm);
+  background: var(--rte-codeblock-bg);
+  overflow-x: auto;
+}
+
+.rte-content .tiptap pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  color: var(--rte-text);
+  font-family: var(--rte-font-mono);
+  font-size: 0.875em;
+  line-height: 1.5;
+}
+
+/* ── Links ─────────────────────────────────────────────── */
+.rte-content .tiptap a {
+  color: var(--rte-link-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.rte-content .tiptap a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* ── Images ────────────────────────────────────────────── */
+.rte-content .tiptap img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--rte-radius-sm);
+}
+
+/* ── Horizontal rule ───────────────────────────────────── */
+.rte-content .tiptap hr {
+  margin: 1.5em 0;
+  border: none;
+  border-top: 1px solid var(--rte-border);
+}
+
+/* ── Bold / Italic / Strike ────────────────────────────── */
+.rte-content .tiptap strong { font-weight: 700; }
+.rte-content .tiptap em { font-style: italic; }
+.rte-content .tiptap s { text-decoration: line-through; }
+.rte-content .tiptap u { text-decoration: underline; }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,1 +1,14 @@
-/* Placeholder base styles */
+/**
+ * Master stylesheet — entry point for the rich-text-editor package.
+ *
+ * Consumers import this via:
+ *   import 'rich-text-editor-ndevu/styles';
+ *
+ * Or it is included automatically when importing the JS entry and
+ * the bundler extracts CSS.
+ */
+
+@import './theme-light.css';
+@import './theme-dark.css';
+@import './editor.css';
+@import './toolbar.css';

--- a/src/styles/theme-dark.css
+++ b/src/styles/theme-dark.css
@@ -1,1 +1,60 @@
-/* Placeholder theme: dark */
+/**
+ * Dark theme — CSS custom property tokens.
+ *
+ * Applied via [data-theme='dark'] on the editor wrapper.
+ * Catppuccin Mocha–inspired palette for comfortable dark editing.
+ */
+
+[data-theme='dark'] {
+  /* ── Surface colors ─────────────────────────────────── */
+  --rte-bg: #1e1e2e;
+  --rte-text: #cdd6f4;
+  --rte-text-muted: #a6adc8;
+  --rte-border: #45475a;
+
+  /* ── Toolbar ────────────────────────────────────────── */
+  --rte-toolbar-bg: #181825;
+  --rte-toolbar-border: #313244;
+
+  /* ── Buttons ────────────────────────────────────────── */
+  --rte-button-hover: #313244;
+  --rte-button-active: #45475a;
+  --rte-button-pressed: #585b70;
+  --rte-button-text: #cdd6f4;
+
+  /* ── Accent & focus ─────────────────────────────────── */
+  --rte-accent: #89b4fa;
+  --rte-placeholder: #585b70;
+  --rte-focus-ring: rgba(137, 180, 250, 0.3);
+
+  /* ── Code ───────────────────────────────────────────── */
+  --rte-code-bg: #313244;
+  --rte-code-text: #cdd6f4;
+  --rte-codeblock-bg: #1e1e2e;
+
+  /* ── Blockquote ─────────────────────────────────────── */
+  --rte-blockquote-border: #585b70;
+  --rte-blockquote-text: #a6adc8;
+
+  /* ── Links ──────────────────────────────────────────── */
+  --rte-link-color: #89b4fa;
+
+  /* ── Dialogs ────────────────────────────────────────── */
+  --rte-dialog-overlay: rgba(0, 0, 0, 0.6);
+  --rte-dialog-bg: #1e1e2e;
+  --rte-dialog-border: #45475a;
+
+  /* ── Form inputs ────────────────────────────────────── */
+  --rte-input-bg: #313244;
+  --rte-input-border: #45475a;
+  --rte-input-focus: #89b4fa;
+
+  /* ── Shared ─────────────────────────────────────────── */
+  --rte-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --rte-radius: 8px;
+  --rte-radius-sm: 4px;
+  --rte-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --rte-font-mono: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
+  --rte-font-size: 16px;
+  --rte-line-height: 1.6;
+}

--- a/src/styles/theme-light.css
+++ b/src/styles/theme-light.css
@@ -1,1 +1,60 @@
-/* Placeholder theme: light */
+/**
+ * Light theme — CSS custom property tokens.
+ *
+ * Applied via [data-theme='light'] on the editor wrapper.
+ * See Appendix C in IMPLEMENTATION_PLAN.md for the full token reference.
+ */
+
+[data-theme='light'] {
+  /* ── Surface colors ─────────────────────────────────── */
+  --rte-bg: #ffffff;
+  --rte-text: #1a1a2e;
+  --rte-text-muted: #6b7280;
+  --rte-border: #e0e0e0;
+
+  /* ── Toolbar ────────────────────────────────────────── */
+  --rte-toolbar-bg: #f8f9fa;
+  --rte-toolbar-border: #e0e0e0;
+
+  /* ── Buttons ────────────────────────────────────────── */
+  --rte-button-hover: #e9ecef;
+  --rte-button-active: #dee2e6;
+  --rte-button-pressed: #d0d7de;
+  --rte-button-text: #374151;
+
+  /* ── Accent & focus ─────────────────────────────────── */
+  --rte-accent: #0969da;
+  --rte-placeholder: #9ca3af;
+  --rte-focus-ring: rgba(9, 105, 218, 0.3);
+
+  /* ── Code ───────────────────────────────────────────── */
+  --rte-code-bg: #f6f8fa;
+  --rte-code-text: #1a1a2e;
+  --rte-codeblock-bg: #f6f8fa;
+
+  /* ── Blockquote ─────────────────────────────────────── */
+  --rte-blockquote-border: #d0d7de;
+  --rte-blockquote-text: #57606a;
+
+  /* ── Links ──────────────────────────────────────────── */
+  --rte-link-color: #0969da;
+
+  /* ── Dialogs ────────────────────────────────────────── */
+  --rte-dialog-overlay: rgba(0, 0, 0, 0.4);
+  --rte-dialog-bg: #ffffff;
+  --rte-dialog-border: #e0e0e0;
+
+  /* ── Form inputs ────────────────────────────────────── */
+  --rte-input-bg: #ffffff;
+  --rte-input-border: #d1d5db;
+  --rte-input-focus: #0969da;
+
+  /* ── Shared ─────────────────────────────────────────── */
+  --rte-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  --rte-radius: 8px;
+  --rte-radius-sm: 4px;
+  --rte-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --rte-font-mono: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
+  --rte-font-size: 16px;
+  --rte-line-height: 1.6;
+}

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -1,1 +1,86 @@
-/* Placeholder toolbar styles */
+/**
+ * Toolbar component styles.
+ *
+ * All classes use the `.rte-toolbar` namespace to prevent leakage.
+ * Colors reference CSS custom properties defined in theme-light/dark.css.
+ */
+
+/* ── Toolbar container ─────────────────────────────────── */
+.rte-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 8px;
+  background: var(--rte-toolbar-bg);
+  border-bottom: 1px solid var(--rte-toolbar-border);
+  user-select: none;
+}
+
+/* ── Button group ──────────────────────────────────────── */
+.rte-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* ── Single button ─────────────────────────────────────── */
+.rte-toolbar__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: var(--rte-radius-sm);
+  background: transparent;
+  color: var(--rte-button-text);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.rte-toolbar__button:hover:not(:disabled) {
+  background: var(--rte-button-hover);
+}
+
+.rte-toolbar__button:active:not(:disabled) {
+  background: var(--rte-button-active);
+}
+
+/* Toggled / pressed state */
+.rte-toolbar__button[aria-pressed='true'] {
+  background: var(--rte-button-pressed);
+  color: var(--rte-accent);
+}
+
+.rte-toolbar__button[aria-pressed='true']:hover:not(:disabled) {
+  background: var(--rte-button-active);
+}
+
+/* Disabled */
+.rte-toolbar__button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Focus-visible (keyboard navigation) */
+.rte-toolbar__button:focus-visible {
+  outline: 2px solid var(--rte-accent);
+  outline-offset: -2px;
+  box-shadow: 0 0 0 3px var(--rte-focus-ring);
+}
+
+/* ── Separator ─────────────────────────────────────────── */
+.rte-toolbar__separator {
+  width: 1px;
+  height: 20px;
+  margin: 0 4px;
+  background: var(--rte-border);
+  flex-shrink: 0;
+}


### PR DESCRIPTION
- theme-light.css: 32 CSS custom property tokens ([data-theme='light'])
- theme-dark.css: 32 tokens, Catppuccin Mocha-inspired palette
- editor.css: wrapper (border, radius, shadow, focus ring), prose typography (headings h1-h6, lists with nested markers, blockquote, inline code, code blocks, links, images, hr, bold/italic/strike/u)
- toolbar.css: button (32x32, hover, active, pressed, disabled, focus-visible), separator, group layout
- index.css: master import for all stylesheets
- Wired .rte-* BEM-style classes into all components
- CSS import in src/index.ts for automatic bundling
- CSS bundle: 7.40 KB | JS: 16.05 KB ESM / 17.01 KB CJS

# PR template

Please describe your changes and link any related issues.
