### PR TITLE
feat: Phase 10 — Lists & blockquotes with sink/lift nesting

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 9 / 25 phases complete | **36% done**
+**Overall:** 10 / 25 phases complete | **40% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -26,7 +26,7 @@
 | 7 | Toolbar System | `Complete` | 2026-03-15 | 2026-03-15 | ToolbarButton, ToolbarSeparator, ToolbarGroup, Toolbar with roving tabindex, wired into EditorWrapper |
 | 8 | Styles & Theming | `Complete` | 2026-03-15 | 2026-03-15 | 32 CSS tokens per theme, .rte-* BEM classes, prose typography, 7.40 KB CSS bundle |
 | 9 | Plugins: Text Formatting & Headings | `Complete` | 2026-03-15 | 2026-03-15 | Underline extension installed, added to schema; StarterKit handles bold/italic/strike/headings |
-| 10 | Plugins: Lists & Blockquotes | `Not Started` | — | — | |
+| 10 | Plugins: Lists & Blockquotes | `Complete` | 2026-03-15 | 2026-03-15 | ListsPlugin with sinkListItem/liftListItem; lists + blockquote already in StarterKit |
 | 11 | Plugins: Links & Link Dialog | `Not Started` | — | — | |
 | 12 | Plugins: Images & Image Dialog | `Not Started` | — | — | |
 | 13 | Plugins: Code Blocks & Syntax HL | `Not Started` | — | — | |
@@ -1423,10 +1423,10 @@ In this phase, we only wire up the text formatting plugins. CodeBlock has its ow
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-10-lists-blockquotes` |
 | **Blocked by** | Phase 8 (parallelizable with 9) |
 | **Deliverables** | `ListsPlugin.tsx`, list/blockquote CSS, Tab/Shift+Tab nesting |
 
@@ -1461,11 +1461,11 @@ Ensure the styles from Phase 8 render correctly:
 
 ### Checkpoint
 
-- [ ] Bullet list toggle works
-- [ ] Ordered list toggle works
-- [ ] Tab/Shift+Tab nests/unnests list items
-- [ ] Blockquote toggle works
-- [ ] Nested structures render correctly
+- [x] Bullet list toggle works
+- [x] Ordered list toggle works
+- [x] Tab/Shift+Tab nests/unnests list items
+- [x] Blockquote toggle works
+- [x] Nested structures render correctly
 
 ---
 
@@ -2978,6 +2978,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 7 | Built toolbar system: ToolbarButton (aria-label/pressed, shortcut hints, fallback text), ToolbarSeparator (role=separator), ToolbarGroup (role=group), Toolbar (groupBySeparator, roving tabindex ArrowLeft/Right/Home/End). Wired Toolbar into EditorWrapper replacing stub. | No CSS Modules yet (Phase 8); icons still null (text labels used); bundle now 15.78KB ESM |
 | 2026-03-15 | 8 | Built styles & theming: theme-light.css + theme-dark.css (32 tokens each), editor.css (wrapper, focus ring, prose typography for headings/lists/blockquote/code/links/images/hr), toolbar.css (button hover/active/pressed/disabled/focus-visible, separator, group), index.css master import. Wired .rte-* classes into all components. CSS bundled via import in src/index.ts. | Used .rte-* BEM-style prefix instead of CSS Modules (better for library consumers); CSS output 7.40 KB |
 | 2026-03-15 | 9 | Installed @tiptap/extension-underline, added Underline to schema.ts extension array. Updated Plugins barrel index with roadmap comments. Bold/italic/strike/headings already functional via StarterKit. | No new component needed — formatting is extension-level; CodeBlockPlugin remains placeholder for Phase 13 |
+| 2026-03-15 | 10 | Created ListsPlugin.tsx with sinkListItem/liftListItem helpers. Added both commands to core/commands.ts + core/index.ts + src/index.ts public API. Updated Plugins barrel. Lists + blockquotes already functional via StarterKit; CSS from Phase 8 handles nested markers. | Tab/Shift+Tab nesting exposed as exported functions; no Tiptap extension override needed |
 
 <!--
 Example entries:

--- a/src/components/Plugins/ListsPlugin.tsx
+++ b/src/components/Plugins/ListsPlugin.tsx
@@ -1,1 +1,28 @@
-// Placeholder for Lists plugin
+/**
+ * Lists & Blockquote Plugin
+ *
+ * StarterKit already registers BulletList, OrderedList, ListItem, and Blockquote.
+ * This module provides helper utilities for list nesting (sink / lift) that
+ * can be wired to Tab / Shift+Tab keyboard shortcuts.
+ *
+ * **Usage (inside a Tiptap extension or keyboard-shortcut map):**
+ * ```ts
+ * import { sinkListItem, liftListItem } from '@/components/Plugins';
+ * ```
+ */
+
+import type { Editor } from '@tiptap/core';
+
+/**
+ * Increase list indent — moves the current list item one level deeper.
+ * Equivalent to pressing Tab inside a list.
+ */
+export const sinkListItem = (editor: Editor): boolean =>
+  editor.chain().focus().sinkListItem('listItem').run();
+
+/**
+ * Decrease list indent — lifts the current list item one level up.
+ * Equivalent to pressing Shift+Tab inside a list.
+ */
+export const liftListItem = (editor: Editor): boolean =>
+  editor.chain().focus().liftListItem('listItem').run();

--- a/src/components/Plugins/index.ts
+++ b/src/components/Plugins/index.ts
@@ -1,7 +1,7 @@
 // Plugins public exports
 // Individual plugin components are exported as they are implemented.
 // Phase 9: Text formatting uses StarterKit + Underline (no component needed)
-// Phase 10: ListsPlugin
+export { sinkListItem, liftListItem } from './ListsPlugin';
 // Phase 11: LinkPlugin
 // Phase 12: ImagePlugin
 // Phase 13: CodeBlockPlugin

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -33,7 +33,13 @@ export const toggleBulletList = (editor: Editor): boolean =>
 
 export const toggleOrderedList = (editor: Editor): boolean =>
   editor.chain().focus().toggleOrderedList().run();
+/** Increase list indent — sink the current list item one level deeper. */
+export const sinkListItem = (editor: Editor): boolean =>
+  editor.chain().focus().sinkListItem('listItem').run();
 
+/** Decrease list indent — lift the current list item one level up. */
+export const liftListItem = (editor: Editor): boolean =>
+  editor.chain().focus().liftListItem('listItem').run();
 // ──────────────────────────────────────────────
 // Block Formatting
 // ──────────────────────────────────────────────

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,8 @@ export {
   setHeading,
   toggleBulletList,
   toggleOrderedList,
+  sinkListItem,
+  liftListItem,
   toggleBlockquote,
   toggleCode,
   toggleCodeBlock,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ export {
   setHeading,
   toggleBulletList,
   toggleOrderedList,
+  sinkListItem,
+  liftListItem,
   toggleBlockquote,
   toggleCode,
   toggleCodeBlock,


### PR DESCRIPTION
- ListsPlugin.tsx: sinkListItem + liftListItem helpers for Tab/Shift+Tab
- Added sinkListItem, liftListItem to core/commands.ts
- Exported both from core barrel and public API (src/index.ts)
- Updated Plugins barrel with ListsPlugin exports
- Lists (bullet/ordered) + blockquote already functional via StarterKit
- Nested list styles (disc/circle/square, decimal/alpha/roman) from Phase 8
- Bundle: 16.31 KB ESM / 17.40 KB CJS | CSS: 7.40 KB

# PR template

Please describe your changes and link any related issues.
