### PR TITLE
feat: Phase 11 — Links & accessible link dialog

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 10 / 25 phases complete | **40% done**
+**Overall:** 11 / 25 phases complete | **44% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -27,7 +27,7 @@
 | 8 | Styles & Theming | `Complete` | 2026-03-15 | 2026-03-15 | 32 CSS tokens per theme, .rte-* BEM classes, prose typography, 7.40 KB CSS bundle |
 | 9 | Plugins: Text Formatting & Headings | `Complete` | 2026-03-15 | 2026-03-15 | Underline extension installed, added to schema; StarterKit handles bold/italic/strike/headings |
 | 10 | Plugins: Lists & Blockquotes | `Complete` | 2026-03-15 | 2026-03-15 | ListsPlugin with sinkListItem/liftListItem; lists + blockquote already in StarterKit |
-| 11 | Plugins: Links & Link Dialog | `Not Started` | — | — | |
+| 11 | Plugins: Links & Link Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Link extension, LinkPlugin helpers, accessible LinkDialog, dialog.css, wired into EditorWrapper |
 | 12 | Plugins: Images & Image Dialog | `Not Started` | — | — | |
 | 13 | Plugins: Code Blocks & Syntax HL | `Not Started` | — | — | |
 | 14 | Plugins: History (Undo / Redo) | `Not Started` | — | — | |
@@ -1473,10 +1473,10 @@ Ensure the styles from Phase 8 render correctly:
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-11-links-dialog` |
 | **Blocked by** | Phase 8 (parallelizable with 9, 10) |
 | **Deliverables** | `LinkPlugin.tsx`, `LinkDialog.tsx`, `@tiptap/extension-link` installed, dialog CSS |
 
@@ -1546,12 +1546,12 @@ Link.configure({
 
 ### Checkpoint
 
-- [ ] Clicking "link" button opens the dialog
-- [ ] Inserting a link wraps selected text in `<a href="...">...</a>`
-- [ ] Clicking an existing link and pressing "link" button shows edit mode
-- [ ] Remove link strips the `<a>` tag
-- [ ] Auto-linking: typing `https://example.com` auto-creates a link
-- [ ] Dialog is keyboard-navigable and screen-reader accessible
+- [x] Clicking "link" button opens the dialog
+- [x] Inserting a link wraps selected text in `<a href="...">...</a>`
+- [x] Clicking an existing link and pressing "link" button shows edit mode
+- [x] Remove link strips the `<a>` tag
+- [x] Auto-linking: typing `https://example.com` auto-creates a link
+- [x] Dialog is keyboard-navigable and screen-reader accessible
 
 ---
 
@@ -2979,6 +2979,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 8 | Built styles & theming: theme-light.css + theme-dark.css (32 tokens each), editor.css (wrapper, focus ring, prose typography for headings/lists/blockquote/code/links/images/hr), toolbar.css (button hover/active/pressed/disabled/focus-visible, separator, group), index.css master import. Wired .rte-* classes into all components. CSS bundled via import in src/index.ts. | Used .rte-* BEM-style prefix instead of CSS Modules (better for library consumers); CSS output 7.40 KB |
 | 2026-03-15 | 9 | Installed @tiptap/extension-underline, added Underline to schema.ts extension array. Updated Plugins barrel index with roadmap comments. Bold/italic/strike/headings already functional via StarterKit. | No new component needed — formatting is extension-level; CodeBlockPlugin remains placeholder for Phase 13 |
 | 2026-03-15 | 10 | Created ListsPlugin.tsx with sinkListItem/liftListItem helpers. Added both commands to core/commands.ts + core/index.ts + src/index.ts public API. Updated Plugins barrel. Lists + blockquotes already functional via StarterKit; CSS from Phase 8 handles nested markers. | Tab/Shift+Tab nesting exposed as exported functions; no Tiptap extension override needed |
+| 2026-03-15 | 11 | Installed @tiptap/extension-link (autolink, linkOnPaste, openOnClick:false). Added Link.configure to schema.ts. Created LinkPlugin.tsx (getActiveLinkAttrs, getSelectedText, applyLink, removeLink). Created LinkDialog.tsx (accessible modal: focus trap, Escape close, Enter submit, URL validation, edit/remove modes). Created dialog.css (overlay, card, inputs, buttons, animations). Wired LinkDialog into EditorWrapper. Updated barrel exports. | Refactored useEffect → state initializers to satisfy react-hooks/set-state-in-effect lint rule; CSS 10.22 KB; ESM 23.46 KB |
 
 <!--
 Example entries:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "packageManager": "yarn@4.13.0",
   "dependencies": {
     "@tiptap/core": "^3.20.1",
+    "@tiptap/extension-link": "^3.20.1",
     "@tiptap/extension-underline": "^3.20.1",
     "@tiptap/pm": "^3.20.1",
     "@tiptap/react": "^3.20.1",

--- a/src/components/Dialogs/LinkDialog.tsx
+++ b/src/components/Dialogs/LinkDialog.tsx
@@ -1,1 +1,225 @@
-// Placeholder for Link dialog
+/**
+ * Link Dialog — accessible modal for inserting/editing links.
+ *
+ * Features:
+ * - role="dialog", aria-modal, aria-labelledby
+ * - Focus trap (Tab cycles through fields and buttons)
+ * - Escape to close
+ * - Auto-focus URL field on open
+ * - Edit mode: pre-fills URL + shows "Remove Link" button
+ * - URL validation: requires protocol or relative path
+ */
+
+import { useState, useRef, useCallback, useLayoutEffect } from 'react';
+import { useEditorStore } from '@/core/store';
+import { getActiveLinkAttrs, getSelectedText, applyLink, removeLink } from '../Plugins/LinkPlugin';
+
+/**
+ * Compute initial dialog state from the current editor selection.
+ * Runs once when the dialog mounts (no effect needed).
+ */
+function getInitialState(editor: import('@tiptap/core').Editor | null) {
+  if (!editor) return { url: '', text: '', isEditMode: false };
+
+  const existingLink = getActiveLinkAttrs(editor);
+  const selectedText = getSelectedText(editor);
+
+  return {
+    url: existingLink?.href ?? '',
+    text: selectedText,
+    isEditMode: !!existingLink,
+  };
+}
+
+export function LinkDialog() {
+  const editor = useEditorStore((s) => s.editor);
+  const setOpenDialog = useEditorStore((s) => s.setOpenDialog);
+
+  const initial = getInitialState(editor);
+  const [url, setUrl] = useState(initial.url);
+  const [text, setText] = useState(initial.text);
+  const [error, setError] = useState('');
+  const [isEditMode] = useState(initial.isEditMode);
+
+  const urlRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ── Auto-focus URL field on mount ──────────────────────────
+  useLayoutEffect(() => {
+    urlRef.current?.focus();
+  }, []);
+
+  // ── URL validation ─────────────────────────────────────────
+  const validateUrl = useCallback((value: string): boolean => {
+    if (!value.trim()) {
+      setError('URL is required');
+      return false;
+    }
+    // Accept http(s), mailto, tel, relative paths, and anchors
+    if (!/^(https?:\/\/|mailto:|tel:|\/|#)/.test(value.trim())) {
+      setError('URL must start with http://, https://, mailto:, tel:, /, or #');
+      return false;
+    }
+    setError('');
+    return true;
+  }, []);
+
+  // ── Close dialog ───────────────────────────────────────────
+  const close = useCallback(() => {
+    setOpenDialog(null);
+  }, [setOpenDialog]);
+
+  // ── Insert / update link ───────────────────────────────────
+  const handleSubmit = useCallback(() => {
+    if (!editor || !validateUrl(url)) return;
+    applyLink(editor, url.trim(), text.trim() || undefined);
+    close();
+  }, [editor, url, text, validateUrl, close]);
+
+  // ── Remove link (edit mode only) ──────────────────────────
+  const handleRemove = useCallback(() => {
+    if (!editor) return;
+    removeLink(editor);
+    close();
+  }, [editor, close]);
+
+  // ── Keyboard: Escape to close, Enter to submit ─────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+        return;
+      }
+
+      // Focus trap
+      if (e.key === 'Tab') {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+
+        const focusable = dialog.querySelectorAll<HTMLElement>(
+          'input, button, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [close, handleSubmit],
+  );
+
+  // ── Click overlay to close ─────────────────────────────────
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) close();
+    },
+    [close],
+  );
+
+  return (
+    <div
+      className="rte-dialog__overlay"
+      onClick={handleOverlayClick}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        className="rte-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rte-link-dialog-title"
+        onKeyDown={handleKeyDown}
+      >
+        <h2 id="rte-link-dialog-title" className="rte-dialog__title">
+          {isEditMode ? 'Edit Link' : 'Insert Link'}
+        </h2>
+
+        <div className="rte-dialog__field">
+          <label htmlFor="rte-link-url" className="rte-dialog__label">
+            URL
+          </label>
+          <input
+            ref={urlRef}
+            id="rte-link-url"
+            className={`rte-dialog__input ${error ? 'rte-dialog__input--error' : ''}`}
+            type="url"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              if (error) setError('');
+            }}
+            placeholder="https://example.com"
+            autoComplete="off"
+          />
+          {error && (
+            <p className="rte-dialog__error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="rte-dialog__field">
+          <label htmlFor="rte-link-text" className="rte-dialog__label">
+            Display text
+          </label>
+          <input
+            id="rte-link-text"
+            className="rte-dialog__input"
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Link text (optional)"
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="rte-dialog__actions">
+          {isEditMode && (
+            <button
+              type="button"
+              className="rte-dialog__button rte-dialog__button--danger"
+              onClick={handleRemove}
+            >
+              Remove Link
+            </button>
+          )}
+          <div className="rte-dialog__actions-right">
+            <button
+              type="button"
+              className="rte-dialog__button rte-dialog__button--secondary"
+              onClick={close}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rte-dialog__button rte-dialog__button--primary"
+              onClick={handleSubmit}
+            >
+              {isEditMode ? 'Update Link' : 'Insert Link'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dialogs/index.ts
+++ b/src/components/Dialogs/index.ts
@@ -1,1 +1,3 @@
 // Dialogs public exports
+export { LinkDialog } from './LinkDialog';
+// Phase 12: ImageDialog

--- a/src/components/Editor/EditorWrapper.tsx
+++ b/src/components/Editor/EditorWrapper.tsx
@@ -2,6 +2,7 @@ import { useEditorStore } from '@/core/store';
 import { useToolbar } from '@/hooks/useToolbar';
 import { Toolbar } from '@/components/Toolbar';
 import { ContentEditable } from '@/components/Content';
+import { LinkDialog } from '@/components/Dialogs/LinkDialog';
 import type { ToolbarItem } from '@/types';
 
 export interface EditorWrapperProps {
@@ -36,6 +37,7 @@ export function EditorWrapper({
   const editor = useEditorStore((s) => s.editor);
   const theme = useEditorStore((s) => s.theme);
   const readOnly = useEditorStore((s) => s.readOnly);
+  const openDialog = useEditorStore((s) => s.openDialog);
   const { items: toolbarItems } = useToolbar(toolbar);
 
   const wrapperClass = ['rte-editor', className].filter(Boolean).join(' ');
@@ -57,7 +59,9 @@ export function EditorWrapper({
         className="rte-content"
       />
 
-      {/* Dialogs rendered here in Phases 11–12 */}
+      {/* Dialogs */}
+      {openDialog === 'link' && <LinkDialog />}
+      {/* Phase 12: openDialog === 'image' && <ImageDialog /> */}
     </div>
   );
 }

--- a/src/components/Plugins/LinkPlugin.tsx
+++ b/src/components/Plugins/LinkPlugin.tsx
@@ -1,1 +1,65 @@
-// Placeholder for Link plugin
+/**
+ * Link Plugin
+ *
+ * Provides helpers for link insertion, editing, and removal.
+ * The Link Tiptap extension is registered in `schema.ts`.
+ * This module exposes utility functions consumed by `LinkDialog`.
+ */
+
+import type { Editor } from '@tiptap/core';
+import { useEditorStore } from '@/core/store';
+
+/** Get the link attributes (`href`) of the currently selected link, if any. */
+export function getActiveLinkAttrs(editor: Editor): { href: string } | null {
+  const attrs = editor.getAttributes('link');
+  if (attrs.href) {
+    return { href: attrs.href as string };
+  }
+  return null;
+}
+
+/** Get the currently selected text in the editor. */
+export function getSelectedText(editor: Editor): string {
+  const { from, to } = editor.state.selection;
+  return editor.state.doc.textBetween(from, to, ' ');
+}
+
+/**
+ * Open the link dialog, pre-filling with current link data if applicable.
+ *
+ * Called by the toolbar button action (wired in `useToolbar`).
+ */
+export function openLinkDialog(): void {
+  useEditorStore.getState().setOpenDialog('link');
+}
+
+/**
+ * Insert or update a link in the editor.
+ *
+ * - If `text` is provided and differs from current selection, replaces selection.
+ * - Otherwise, applies the link mark to the current selection.
+ */
+export function applyLink(editor: Editor, href: string, text?: string): boolean {
+  if (text) {
+    // Delete current selection and insert new text with link
+    const { from, to } = editor.state.selection;
+    const selectedText = editor.state.doc.textBetween(from, to, ' ');
+
+    if (text !== selectedText) {
+      return editor
+        .chain()
+        .focus()
+        .deleteSelection()
+        .insertContent(`<a href="${href}">${text}</a>`)
+        .run();
+    }
+  }
+
+  // Apply link to existing selection
+  return editor.chain().focus().setLink({ href }).run();
+}
+
+/** Remove the link mark from the current selection. */
+export function removeLink(editor: Editor): boolean {
+  return editor.chain().focus().unsetLink().run();
+}

--- a/src/components/Plugins/index.ts
+++ b/src/components/Plugins/index.ts
@@ -2,7 +2,7 @@
 // Individual plugin components are exported as they are implemented.
 // Phase 9: Text formatting uses StarterKit + Underline (no component needed)
 export { sinkListItem, liftListItem } from './ListsPlugin';
-// Phase 11: LinkPlugin
+export { getActiveLinkAttrs, getSelectedText, applyLink, removeLink } from './LinkPlugin';
 // Phase 12: ImagePlugin
 // Phase 13: CodeBlockPlugin
 // Phase 14: HistoryPlugin

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,6 +1,7 @@
 import type { Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
+import Link from '@tiptap/extension-link';
 
 /**
  * Assemble the base Tiptap extension stack.
@@ -11,7 +12,7 @@ import Underline from '@tiptap/extension-underline';
  *
  * Additional extensions:
  * - Phase 9:  Underline (not in StarterKit)
- * - Phase 11: Link
+ * - Phase 11: Link (autolink, paste-link, opens in new tab)
  * - Phase 12: Image
  * - Phase 13: CodeBlockLowlight (replaces StarterKit's codeBlock)
  * - Phase 14: Custom history config
@@ -24,5 +25,14 @@ export function createExtensions(): Extensions {
       // codeBlock: false,    // Phase 13 — replaced by code-block-lowlight
     }),
     Underline,
+    Link.configure({
+      openOnClick: false,
+      autolink: true,
+      linkOnPaste: true,
+      HTMLAttributes: {
+        rel: 'noopener noreferrer nofollow',
+        target: '_blank',
+      },
+    }),
   ];
 }

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -1,0 +1,169 @@
+/**
+ * Dialog component styles.
+ *
+ * Used by LinkDialog and ImageDialog modals.
+ * Colors reference CSS custom properties defined in theme files.
+ */
+
+/* ── Overlay backdrop ──────────────────────────────────── */
+.rte-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--rte-dialog-overlay);
+  animation: rte-fade-in 0.15s ease;
+}
+
+/* ── Dialog card ───────────────────────────────────────── */
+.rte-dialog {
+  position: relative;
+  width: 90%;
+  max-width: 440px;
+  padding: 24px;
+  border: 1px solid var(--rte-dialog-border);
+  border-radius: var(--rte-radius);
+  background: var(--rte-dialog-bg);
+  color: var(--rte-text);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+  animation: rte-slide-up 0.2s ease;
+}
+
+/* ── Title ─────────────────────────────────────────────── */
+.rte-dialog__title {
+  margin: 0 0 16px;
+  font-size: 1.1em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+/* ── Field wrapper ─────────────────────────────────────── */
+.rte-dialog__field {
+  margin-bottom: 14px;
+}
+
+/* ── Label ─────────────────────────────────────────────── */
+.rte-dialog__label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--rte-text-muted);
+}
+
+/* ── Input ─────────────────────────────────────────────── */
+.rte-dialog__input {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--rte-input-border);
+  border-radius: var(--rte-radius-sm);
+  background: var(--rte-input-bg);
+  color: var(--rte-text);
+  font-family: inherit;
+  font-size: 0.9em;
+  line-height: 1.5;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+}
+
+.rte-dialog__input:focus {
+  border-color: var(--rte-input-focus);
+  box-shadow: 0 0 0 3px var(--rte-focus-ring);
+}
+
+.rte-dialog__input--error {
+  border-color: #e53e3e;
+}
+
+.rte-dialog__input--error:focus {
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.3);
+}
+
+/* ── Error message ─────────────────────────────────────── */
+.rte-dialog__error {
+  margin: 4px 0 0;
+  font-size: 0.8em;
+  color: #e53e3e;
+}
+
+/* ── Actions row ───────────────────────────────────────── */
+.rte-dialog__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.rte-dialog__actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+/* ── Buttons ───────────────────────────────────────────── */
+.rte-dialog__button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--rte-radius-sm);
+  font-family: inherit;
+  font-size: 0.85em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.rte-dialog__button:focus-visible {
+  outline: 2px solid var(--rte-accent);
+  outline-offset: 2px;
+}
+
+.rte-dialog__button--primary {
+  background: var(--rte-accent);
+  color: #ffffff;
+}
+
+.rte-dialog__button--primary:hover {
+  filter: brightness(1.1);
+}
+
+.rte-dialog__button--secondary {
+  background: transparent;
+  color: var(--rte-text-muted);
+}
+
+.rte-dialog__button--secondary:hover {
+  background: var(--rte-button-hover);
+  color: var(--rte-text);
+}
+
+.rte-dialog__button--danger {
+  background: transparent;
+  color: #e53e3e;
+}
+
+.rte-dialog__button--danger:hover {
+  background: rgba(229, 62, 62, 0.1);
+}
+
+/* ── Animations ────────────────────────────────────────── */
+@keyframes rte-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes rte-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,3 +12,4 @@
 @import './theme-dark.css';
 @import './editor.css';
 @import './toolbar.css';
+@import './dialog.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,6 +4965,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
     "@tiptap/core": "npm:^3.20.1"
+    "@tiptap/extension-link": "npm:^3.20.1"
     "@tiptap/extension-underline": "npm:^3.20.1"
     "@tiptap/pm": "npm:^3.20.1"
     "@tiptap/react": "npm:^3.20.1"


### PR DESCRIPTION
- Installed @tiptap/extension-link (autolink, linkOnPaste, target=_blank)
- Link.configure added to schema.ts extension stack
- LinkPlugin.tsx: getActiveLinkAttrs, getSelectedText, applyLink, removeLink
- LinkDialog.tsx: accessible modal (aria-modal, focus trap, Escape close, Enter submit, URL validation, edit/remove modes, auto-focus URL field)
- dialog.css: overlay backdrop, card layout, inputs, buttons (primary, secondary, danger), error states, fade-in/slide-up animations
- Wired LinkDialog into EditorWrapper (openDialog === 'link')
- Updated Dialogs + Plugins barrel exports
- Bundle: 23.46 KB ESM / 24.83 KB CJS | CSS: 10.22 KB

# PR template

Please describe your changes and link any related issues.
