### PR TITLE
feat: Phase 12 — Images & accessible image dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.vscode/settings.json

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 11 / 25 phases complete | **44% done**
+**Overall:** 12 / 25 phases complete | **48% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -28,7 +28,7 @@
 | 9 | Plugins: Text Formatting & Headings | `Complete` | 2026-03-15 | 2026-03-15 | Underline extension installed, added to schema; StarterKit handles bold/italic/strike/headings |
 | 10 | Plugins: Lists & Blockquotes | `Complete` | 2026-03-15 | 2026-03-15 | ListsPlugin with sinkListItem/liftListItem; lists + blockquote already in StarterKit |
 | 11 | Plugins: Links & Link Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Link extension, LinkPlugin helpers, accessible LinkDialog, dialog.css, wired into EditorWrapper |
-| 12 | Plugins: Images & Image Dialog | `Not Started` | — | — | |
+| 12 | Plugins: Images & Image Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Image extension, ImagePlugin (URL + base64), accessible ImageDialog (drag-drop, preview), dialog.css extensions |
 | 13 | Plugins: Code Blocks & Syntax HL | `Not Started` | — | — | |
 | 14 | Plugins: History (Undo / Redo) | `Not Started` | — | — | |
 | 15 | Clipboard, Paste Handling & Utilities | `Not Started` | — | — | |
@@ -1559,10 +1559,10 @@ Link.configure({
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-12-images-dialog` |
 | **Blocked by** | Phase 8 (parallelizable with 9–11) |
 | **Deliverables** | `ImagePlugin.tsx`, `ImageDialog.tsx`, `@tiptap/extension-image` installed |
 
@@ -1631,11 +1631,11 @@ Image.configure({
 
 ### Checkpoint
 
-- [ ] Inserting an image via URL renders `<img src="..." alt="..." />`
-- [ ] Uploading a file converts to base64 and inserts correctly
-- [ ] Image is block-level, centered, max-width 100%
-- [ ] Alt text is included in the output HTML
-- [ ] Dialog fully accessible
+- [x] Inserting an image via URL renders `<img src="..." alt="..." />`
+- [x] Uploading a file converts to base64 and inserts correctly
+- [x] Image is block-level, centered, max-width 100%
+- [x] Alt text is included in the output HTML
+- [x] Dialog fully accessible
 
 ---
 
@@ -2980,6 +2980,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 9 | Installed @tiptap/extension-underline, added Underline to schema.ts extension array. Updated Plugins barrel index with roadmap comments. Bold/italic/strike/headings already functional via StarterKit. | No new component needed — formatting is extension-level; CodeBlockPlugin remains placeholder for Phase 13 |
 | 2026-03-15 | 10 | Created ListsPlugin.tsx with sinkListItem/liftListItem helpers. Added both commands to core/commands.ts + core/index.ts + src/index.ts public API. Updated Plugins barrel. Lists + blockquotes already functional via StarterKit; CSS from Phase 8 handles nested markers. | Tab/Shift+Tab nesting exposed as exported functions; no Tiptap extension override needed |
 | 2026-03-15 | 11 | Installed @tiptap/extension-link (autolink, linkOnPaste, openOnClick:false). Added Link.configure to schema.ts. Created LinkPlugin.tsx (getActiveLinkAttrs, getSelectedText, applyLink, removeLink). Created LinkDialog.tsx (accessible modal: focus trap, Escape close, Enter submit, URL validation, edit/remove modes). Created dialog.css (overlay, card, inputs, buttons, animations). Wired LinkDialog into EditorWrapper. Updated barrel exports. | Refactored useEffect → state initializers to satisfy react-hooks/set-state-in-effect lint rule; CSS 10.22 KB; ESM 23.46 KB |
+| 2026-03-15 | 12 | Installed @tiptap/extension-image (inline:false, allowBase64:true, loading:lazy). Added Image.configure to schema.ts. Created ImagePlugin.tsx (insertImageByUrl, insertImageBase64, readFileAsBase64, MAX_IMAGE_SIZE). Created ImageDialog.tsx (accessible modal: drag-drop zone, file upload with FileReader base64, URL input, alt text, preview thumbnail, 5MB warning). Extended dialog.css (dropzone, file info, separator, warning, preview). Wired ImageDialog into EditorWrapper. Updated all barrel exports + public API. | CSS 13.15 KB (+2.93 KB); ESM 33.95 KB (+10.49 KB) |
 
 <!--
 Example entries:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "packageManager": "yarn@4.13.0",
   "dependencies": {
     "@tiptap/core": "^3.20.1",
+    "@tiptap/extension-image": "^3.20.1",
     "@tiptap/extension-link": "^3.20.1",
     "@tiptap/extension-underline": "^3.20.1",
     "@tiptap/pm": "^3.20.1",

--- a/src/components/Dialogs/ImageDialog.tsx
+++ b/src/components/Dialogs/ImageDialog.tsx
@@ -1,1 +1,357 @@
-// Placeholder for Image dialog
+/**
+ * Image Dialog — accessible modal for inserting images.
+ *
+ * Features:
+ * - URL input with image preview
+ * - File upload via browse button or drag-and-drop
+ * - Base64 conversion for uploaded files
+ * - Alt text input (recommended)
+ * - File size warning (> 5 MB)
+ * - Same a11y patterns as LinkDialog:
+ *   role="dialog", aria-modal, focus trap, Escape to close
+ */
+
+import { useState, useRef, useCallback, useLayoutEffect } from 'react';
+import { useEditorStore } from '@/core/store';
+import {
+  insertImageByUrl,
+  insertImageBase64,
+  readFileAsBase64,
+  MAX_IMAGE_SIZE,
+} from '../Plugins/ImagePlugin';
+
+type ImageSource = 'url' | 'file';
+
+export function ImageDialog() {
+  const editor = useEditorStore((s) => s.editor);
+  const setOpenDialog = useEditorStore((s) => s.setOpenDialog);
+
+  const [source, setSource] = useState<ImageSource>('url');
+  const [url, setUrl] = useState('');
+  const [alt, setAlt] = useState('');
+  const [error, setError] = useState('');
+  const [filePreview, setFilePreview] = useState<string | null>(null);
+  const [fileName, setFileName] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const [sizeWarning, setSizeWarning] = useState('');
+
+  const urlRef = useRef<HTMLInputElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ── Auto-focus URL field on mount ──────────────────────────
+  useLayoutEffect(() => {
+    urlRef.current?.focus();
+  }, []);
+
+  // ── URL validation ─────────────────────────────────────────
+  const validateUrl = useCallback((value: string): boolean => {
+    if (!value.trim()) {
+      setError('Image URL is required');
+      return false;
+    }
+    if (!/^(https?:\/\/|data:image\/|\/|\.\.?\/)/.test(value.trim())) {
+      setError('URL must start with http://, https://, or be a relative path');
+      return false;
+    }
+    setError('');
+    return true;
+  }, []);
+
+  // ── Close dialog ───────────────────────────────────────────
+  const close = useCallback(() => {
+    setOpenDialog(null);
+  }, [setOpenDialog]);
+
+  // ── Process a file (shared by browse & drag-and-drop) ──────
+  const processFile = useCallback(async (file: File) => {
+    if (!file.type.startsWith('image/')) {
+      setError('Please select an image file');
+      return;
+    }
+
+    setSizeWarning('');
+    if (file.size > MAX_IMAGE_SIZE) {
+      const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+      setSizeWarning(`File is ${sizeMB} MB. Large images may slow down the editor.`);
+    }
+
+    try {
+      const dataUri = await readFileAsBase64(file);
+      setFilePreview(dataUri);
+      setFileName(file.name);
+      setSource('file');
+      setError('');
+    } catch {
+      setError('Failed to read file');
+    }
+  }, []);
+
+  // ── File input change ──────────────────────────────────────
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) void processFile(file);
+    },
+    [processFile],
+  );
+
+  // ── Drag-and-drop handlers ─────────────────────────────────
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+
+      const file = e.dataTransfer.files[0];
+      if (file) void processFile(file);
+    },
+    [processFile],
+  );
+
+  // ── Submit: insert image ───────────────────────────────────
+  const handleSubmit = useCallback(() => {
+    if (!editor) return;
+
+    if (source === 'url') {
+      if (!validateUrl(url)) return;
+      insertImageByUrl(editor, url.trim(), alt.trim() || undefined);
+    } else {
+      if (!filePreview) {
+        setError('Please select or drop an image file');
+        return;
+      }
+      insertImageBase64(editor, filePreview, alt.trim() || undefined);
+    }
+
+    close();
+  }, [editor, source, url, alt, filePreview, validateUrl, close]);
+
+  // ── Keyboard: Escape to close, Enter to submit ─────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+        return;
+      }
+
+      // Focus trap
+      if (e.key === 'Tab') {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+
+        const focusable = dialog.querySelectorAll<HTMLElement>(
+          'input, button, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [close, handleSubmit],
+  );
+
+  // ── Click overlay to close ─────────────────────────────────
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) close();
+    },
+    [close],
+  );
+
+  // ── Clear file and reset to URL mode ───────────────────────
+  const clearFile = useCallback(() => {
+    setFilePreview(null);
+    setFileName('');
+    setSizeWarning('');
+    setSource('url');
+    if (fileRef.current) fileRef.current.value = '';
+  }, []);
+
+  // ── Compute preview URL (either file preview or typed URL) ─
+  const previewSrc = source === 'file' ? filePreview : url.trim() || null;
+  const showPreview = !!previewSrc;
+
+  return (
+    <div className="rte-dialog__overlay" onClick={handleOverlayClick} role="presentation">
+      <div
+        ref={dialogRef}
+        className="rte-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rte-image-dialog-title"
+        onKeyDown={handleKeyDown}
+      >
+        <h2 id="rte-image-dialog-title" className="rte-dialog__title">
+          Insert Image
+        </h2>
+
+        {/* ── Drop zone / file upload ───────────────────── */}
+        <div
+          className={`rte-dialog__dropzone ${isDragging ? 'rte-dialog__dropzone--active' : ''}`}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {filePreview ? (
+            <div className="rte-dialog__file-info">
+              <span className="rte-dialog__file-name">{fileName}</span>
+              <button
+                type="button"
+                className="rte-dialog__file-clear"
+                onClick={clearFile}
+                aria-label="Remove selected file"
+              >
+                ×
+              </button>
+            </div>
+          ) : (
+            <p className="rte-dialog__dropzone-text">
+              Drag &amp; drop an image, or{' '}
+              <button
+                type="button"
+                className="rte-dialog__browse-button"
+                onClick={() => fileRef.current?.click()}
+              >
+                browse
+              </button>
+            </p>
+          )}
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="rte-dialog__file-input"
+            onChange={handleFileChange}
+            tabIndex={-1}
+            aria-hidden="true"
+          />
+        </div>
+
+        {sizeWarning && (
+          <p className="rte-dialog__warning" role="status">
+            {sizeWarning}
+          </p>
+        )}
+
+        {/* ── Separator ─────────────────────────────────── */}
+        <div className="rte-dialog__separator">
+          <span>or enter URL</span>
+        </div>
+
+        {/* ── URL input ─────────────────────────────────── */}
+        <div className="rte-dialog__field">
+          <label htmlFor="rte-image-url" className="rte-dialog__label">
+            Image URL
+          </label>
+          <input
+            ref={urlRef}
+            id="rte-image-url"
+            className={`rte-dialog__input ${error && source === 'url' ? 'rte-dialog__input--error' : ''}`}
+            type="url"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              if (error) setError('');
+              if (e.target.value.trim()) setSource('url');
+            }}
+            placeholder="https://example.com/photo.jpg"
+            autoComplete="off"
+          />
+        </div>
+
+        {/* ── Alt text ──────────────────────────────────── */}
+        <div className="rte-dialog__field">
+          <label htmlFor="rte-image-alt" className="rte-dialog__label">
+            Alt text (recommended)
+          </label>
+          <input
+            id="rte-image-alt"
+            className="rte-dialog__input"
+            type="text"
+            value={alt}
+            onChange={(e) => setAlt(e.target.value)}
+            placeholder="Describe the image"
+            autoComplete="off"
+          />
+        </div>
+
+        {/* ── Preview ───────────────────────────────────── */}
+        {showPreview && (
+          <div className="rte-dialog__preview">
+            <img
+              src={previewSrc!}
+              alt={alt || 'Preview'}
+              className="rte-dialog__preview-image"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+              onLoad={(e) => {
+                (e.target as HTMLImageElement).style.display = 'block';
+              }}
+            />
+          </div>
+        )}
+
+        {/* ── Error ──────────────────────────────────────── */}
+        {error && (
+          <p className="rte-dialog__error" role="alert">
+            {error}
+          </p>
+        )}
+
+        {/* ── Actions ────────────────────────────────────── */}
+        <div className="rte-dialog__actions">
+          <div className="rte-dialog__actions-right">
+            <button
+              type="button"
+              className="rte-dialog__button rte-dialog__button--secondary"
+              onClick={close}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rte-dialog__button rte-dialog__button--primary"
+              onClick={handleSubmit}
+            >
+              Insert Image
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dialogs/index.ts
+++ b/src/components/Dialogs/index.ts
@@ -1,3 +1,3 @@
 // Dialogs public exports
 export { LinkDialog } from './LinkDialog';
-// Phase 12: ImageDialog
+export { ImageDialog } from './ImageDialog';

--- a/src/components/Editor/EditorWrapper.tsx
+++ b/src/components/Editor/EditorWrapper.tsx
@@ -3,6 +3,7 @@ import { useToolbar } from '@/hooks/useToolbar';
 import { Toolbar } from '@/components/Toolbar';
 import { ContentEditable } from '@/components/Content';
 import { LinkDialog } from '@/components/Dialogs/LinkDialog';
+import { ImageDialog } from '@/components/Dialogs/ImageDialog';
 import type { ToolbarItem } from '@/types';
 
 export interface EditorWrapperProps {
@@ -61,7 +62,7 @@ export function EditorWrapper({
 
       {/* Dialogs */}
       {openDialog === 'link' && <LinkDialog />}
-      {/* Phase 12: openDialog === 'image' && <ImageDialog /> */}
+      {openDialog === 'image' && <ImageDialog />}
     </div>
   );
 }

--- a/src/components/Plugins/ImagePlugin.tsx
+++ b/src/components/Plugins/ImagePlugin.tsx
@@ -1,1 +1,77 @@
-// Placeholder for Image plugin
+/**
+ * Image Plugin — helpers for image insertion.
+ *
+ * Uses @tiptap/extension-image configured in schema.ts.
+ * Provides:
+ * - insertImageByUrl:  insert an image node from a URL
+ * - insertImageBase64: insert an image node from a base64 data URI
+ * - readFileAsBase64:  convert a File to a base64 data URI (async)
+ * - openImageDialog:   convenience to open the image dialog via store
+ * - MAX_IMAGE_SIZE:    soft limit for file size warnings (5 MB)
+ */
+
+import type { Editor } from '@tiptap/core';
+import { useEditorStore } from '@/core/store';
+
+/** Maximum recommended image file size in bytes (5 MB). */
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+
+/**
+ * Insert an image into the editor via URL.
+ *
+ * @param editor - Tiptap editor instance
+ * @param src    - Image URL
+ * @param alt    - Alt text (optional but recommended)
+ * @returns true if the command ran successfully
+ */
+export function insertImageByUrl(editor: Editor, src: string, alt?: string): boolean {
+  return editor
+    .chain()
+    .focus()
+    .setImage({ src, alt: alt || '' })
+    .run();
+}
+
+/**
+ * Insert an image into the editor from a base64 data URI.
+ *
+ * @param editor  - Tiptap editor instance
+ * @param dataUri - base64 data URI (e.g. `data:image/png;base64,...`)
+ * @param alt     - Alt text (optional but recommended)
+ * @returns true if the command ran successfully
+ */
+export function insertImageBase64(editor: Editor, dataUri: string, alt?: string): boolean {
+  return editor
+    .chain()
+    .focus()
+    .setImage({ src: dataUri, alt: alt || '' })
+    .run();
+}
+
+/**
+ * Read a File object and return a base64 data URI.
+ *
+ * @param file - File from `<input type="file">` or drag-and-drop
+ * @returns Promise resolving to a data URI string
+ */
+export function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('FileReader result is not a string'));
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Open the image dialog via the editor store.
+ */
+export function openImageDialog(): void {
+  useEditorStore.getState().setOpenDialog('image');
+}

--- a/src/components/Plugins/index.ts
+++ b/src/components/Plugins/index.ts
@@ -3,6 +3,12 @@
 // Phase 9: Text formatting uses StarterKit + Underline (no component needed)
 export { sinkListItem, liftListItem } from './ListsPlugin';
 export { getActiveLinkAttrs, getSelectedText, applyLink, removeLink } from './LinkPlugin';
-// Phase 12: ImagePlugin
+export {
+  insertImageByUrl,
+  insertImageBase64,
+  readFileAsBase64,
+  openImageDialog,
+  MAX_IMAGE_SIZE,
+} from './ImagePlugin';
 // Phase 13: CodeBlockPlugin
 // Phase 14: HistoryPlugin

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -2,6 +2,7 @@ import type { Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
+import Image from '@tiptap/extension-image';
 
 /**
  * Assemble the base Tiptap extension stack.
@@ -13,7 +14,7 @@ import Link from '@tiptap/extension-link';
  * Additional extensions:
  * - Phase 9:  Underline (not in StarterKit)
  * - Phase 11: Link (autolink, paste-link, opens in new tab)
- * - Phase 12: Image
+ * - Phase 12: Image (block-level, base64 allowed, lazy loading)
  * - Phase 13: CodeBlockLowlight (replaces StarterKit's codeBlock)
  * - Phase 14: Custom history config
  */
@@ -32,6 +33,13 @@ export function createExtensions(): Extensions {
       HTMLAttributes: {
         rel: 'noopener noreferrer nofollow',
         target: '_blank',
+      },
+    }),
+    Image.configure({
+      inline: false,
+      allowBase64: true,
+      HTMLAttributes: {
+        loading: 'lazy',
       },
     }),
   ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,3 +57,12 @@ export {
   redo,
 } from './core';
 export { toHTML, fromHTML, createEmptyDoc, isContentEmpty } from './core';
+
+// Image plugin utilities (advanced usage)
+export {
+  insertImageByUrl,
+  insertImageBase64,
+  readFileAsBase64,
+  openImageDialog,
+  MAX_IMAGE_SIZE,
+} from './components/Plugins/ImagePlugin';

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -167,3 +167,159 @@
     transform: translateY(0);
   }
 }
+
+/* ──────────────────────────────────────────────────────── */
+/*  Image Dialog — Drop zone, preview, separator, warning   */
+/* ──────────────────────────────────────────────────────── */
+
+/* ── Drop zone ─────────────────────────────────────────── */
+.rte-dialog__dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  margin-bottom: 12px;
+  padding: 16px;
+  border: 2px dashed var(--rte-input-border);
+  border-radius: var(--rte-radius-sm);
+  background: var(--rte-input-bg);
+  text-align: center;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.rte-dialog__dropzone--active {
+  border-color: var(--rte-accent);
+  background: var(--rte-button-hover);
+}
+
+.rte-dialog__dropzone-text {
+  margin: 0;
+  font-size: 0.85em;
+  color: var(--rte-text-muted);
+}
+
+.rte-dialog__browse-button {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--rte-accent);
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.rte-dialog__browse-button:hover {
+  filter: brightness(1.1);
+}
+
+.rte-dialog__browse-button:focus-visible {
+  outline: 2px solid var(--rte-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Hidden file input */
+.rte-dialog__file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* ── File info (after selection) ───────────────────────── */
+.rte-dialog__file-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rte-dialog__file-name {
+  font-size: 0.85em;
+  color: var(--rte-text);
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rte-dialog__file-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--rte-button-hover);
+  color: var(--rte-text-muted);
+  font-size: 1em;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.rte-dialog__file-clear:hover {
+  background: #e53e3e;
+  color: #ffffff;
+}
+
+.rte-dialog__file-clear:focus-visible {
+  outline: 2px solid var(--rte-accent);
+  outline-offset: 2px;
+}
+
+/* ── Separator (—— or enter URL ——) ────────────────────── */
+.rte-dialog__separator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 0 14px;
+  color: var(--rte-text-muted);
+  font-size: 0.8em;
+}
+
+.rte-dialog__separator::before,
+.rte-dialog__separator::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--rte-border);
+}
+
+/* ── Size warning ──────────────────────────────────────── */
+.rte-dialog__warning {
+  margin: 0 0 10px;
+  padding: 6px 10px;
+  border-radius: var(--rte-radius-sm);
+  background: rgba(237, 137, 54, 0.1);
+  color: #dd6b20;
+  font-size: 0.8em;
+}
+
+/* ── Image preview ─────────────────────────────────────── */
+.rte-dialog__preview {
+  margin-bottom: 14px;
+  padding: 8px;
+  border: 1px solid var(--rte-border);
+  border-radius: var(--rte-radius-sm);
+  background: var(--rte-input-bg);
+  text-align: center;
+  overflow: hidden;
+}
+
+.rte-dialog__preview-image {
+  max-width: 100%;
+  max-height: 160px;
+  border-radius: var(--rte-radius-sm);
+  object-fit: contain;
+}

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -177,9 +177,17 @@
 
 /* ── Images ────────────────────────────────────────────── */
 .rte-content .tiptap img {
+  display: block;
   max-width: 100%;
   height: auto;
+  margin: 0.75em auto;
   border-radius: var(--rte-radius-sm);
+}
+
+/* Selected image node (ProseMirror selected) */
+.rte-content .tiptap img.ProseMirror-selectednode {
+  outline: 2px solid var(--rte-accent);
+  outline-offset: 2px;
 }
 
 /* ── Horizontal rule ───────────────────────────────────── */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tiptap/extension-image@npm:^3.20.1":
+  version: 3.20.1
+  resolution: "@tiptap/extension-image@npm:3.20.1"
+  peerDependencies:
+    "@tiptap/core": ^3.20.1
+  checksum: 10c0/f9ea71d869e260cbad0d2668005070ac99a592f964de89fbe9b7b3131711919a170127215b52a9d37984adedb66172cb5de0a6221cafa0654c94079b230ab065
+  languageName: node
+  linkType: hard
+
 "@tiptap/extension-italic@npm:^3.20.1":
   version: 3.20.1
   resolution: "@tiptap/extension-italic@npm:3.20.1"
@@ -4965,6 +4974,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
     "@tiptap/core": "npm:^3.20.1"
+    "@tiptap/extension-image": "npm:^3.20.1"
     "@tiptap/extension-link": "npm:^3.20.1"
     "@tiptap/extension-underline": "npm:^3.20.1"
     "@tiptap/pm": "npm:^3.20.1"


### PR DESCRIPTION
- Installed @tiptap/extension-image (inline:false, allowBase64:true, lazy)
- Image.configure added to schema.ts extension stack
- ImagePlugin.tsx: insertImageByUrl, insertImageBase64, readFileAsBase64, openImageDialog, MAX_IMAGE_SIZE (5 MB)
- ImageDialog.tsx: accessible modal (aria-modal, focus trap, Escape close, Enter submit) with drag-and-drop zone, file upload via FileReader base64, URL input, alt text field, image preview thumbnail, 5 MB size warning
- Extended dialog.css: dropzone (dashed border, active state), file info, browse button, separator (or-divider), warning banner, preview card
- Updated editor.css: block-level images centered, selected-node outline
- Wired ImageDialog into EditorWrapper (openDialog === 'image')
- Updated Plugins + Dialogs barrel exports, public API in src/index.ts
- Added .vscode/settings.json to .gitignore
- Bundle: 33.95 KB ESM / 35.96 KB CJS | CSS: 13.15 KB

# PR template

Please describe your changes and link any related issues.
