### PR TITLE
feat: Phase 14 — History (Undo / Redo)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 13 / 25 phases complete | **52% done**
+**Overall:** 14 / 25 phases complete | **56% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -30,7 +30,7 @@
 | 11 | Plugins: Links & Link Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Link extension, LinkPlugin helpers, accessible LinkDialog, dialog.css, wired into EditorWrapper |
 | 12 | Plugins: Images & Image Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Image extension, ImagePlugin (URL + base64), accessible ImageDialog (drag-drop, preview), dialog.css extensions |
 | 13 | Plugins: Code Blocks & Syntax HL | `Complete` | 2026-03-15 | 2026-03-15 | CodeBlockLowlight + lowlight (common bundle), highlight.css (light GitHub + dark Catppuccin) |
-| 14 | Plugins: History (Undo / Redo) | `Not Started` | — | — | |
+| 14 | Plugins: History (Undo / Redo) | `Complete` | 2026-03-15 | 2026-03-15 | StarterKit undoRedo configured (depth:100, newGroupDelay:500), undo/redo buttons disabled via canUndo/canRedo |
 | 15 | Clipboard, Paste Handling & Utilities | `Not Started` | — | — | |
 | 16 | Accessibility & Keyboard Navigation | `Not Started` | — | — | |
 | 17 | Playground App | `Not Started` | — | — | |
@@ -1709,10 +1709,10 @@ Add styles for `.hljs` (highlight.js) theme classes inside code blocks:
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-14-history` |
 | **Blocked by** | Phase 8 (parallelizable with 9–13) |
 | **Deliverables** | `HistoryPlugin.tsx`, `src/components/Plugins/index.ts` |
 
@@ -1741,12 +1741,12 @@ export { HistoryPlugin } from './HistoryPlugin';
 
 ### Checkpoint
 
-- [ ] Undo button reverses last action
-- [ ] Redo button re-applies undone action
-- [ ] Undo button disabled when history is empty
-- [ ] Redo button disabled when nothing to redo
-- [ ] Keyboard shortcuts work
-- [ ] History survives plugin operations (e.g., inserting a link is undoable)
+- [x] Undo button reverses last action
+- [x] Redo button re-applies undone action
+- [x] Undo button disabled when history is empty
+- [x] Redo button disabled when nothing to redo
+- [x] Keyboard shortcuts work
+- [x] History survives plugin operations (e.g., inserting a link is undoable)
 
 ---
 
@@ -2982,6 +2982,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 11 | Installed @tiptap/extension-link (autolink, linkOnPaste, openOnClick:false). Added Link.configure to schema.ts. Created LinkPlugin.tsx (getActiveLinkAttrs, getSelectedText, applyLink, removeLink). Created LinkDialog.tsx (accessible modal: focus trap, Escape close, Enter submit, URL validation, edit/remove modes). Created dialog.css (overlay, card, inputs, buttons, animations). Wired LinkDialog into EditorWrapper. Updated barrel exports. | Refactored useEffect → state initializers to satisfy react-hooks/set-state-in-effect lint rule; CSS 10.22 KB; ESM 23.46 KB |
 | 2026-03-15 | 12 | Installed @tiptap/extension-image (inline:false, allowBase64:true, loading:lazy). Added Image.configure to schema.ts. Created ImagePlugin.tsx (insertImageByUrl, insertImageBase64, readFileAsBase64, MAX_IMAGE_SIZE). Created ImageDialog.tsx (accessible modal: drag-drop zone, file upload with FileReader base64, URL input, alt text, preview thumbnail, 5MB warning). Extended dialog.css (dropzone, file info, separator, warning, preview). Wired ImageDialog into EditorWrapper. Updated all barrel exports + public API. | CSS 13.15 KB (+2.93 KB); ESM 33.95 KB (+10.49 KB) |
 | 2026-03-15 | 13 | Installed @tiptap/extension-code-block-lowlight + lowlight + @tiptap/extension-code-block + highlight.js (peers). Disabled StarterKit codeBlock, added CodeBlockLowlight.configure with lowlight (common bundle). Created CodeBlockPlugin.tsx (getCodeBlockLanguage, setCodeBlockLanguage, SUPPORTED_LANGUAGES). Created highlight.css (GitHub-like light + Catppuccin-inspired dark syntax colors for all hljs classes). Exported lowlight instance for consumer language registration. | CSS 17.85 KB (+4.70 KB); ESM 35.40 KB (+1.45 KB); language selector is exported helper, not a UI component yet |
+| 2026-03-15 | 14 | Configured StarterKit undoRedo (depth:100, newGroupDelay:500) in schema.ts. Created HistoryPlugin.tsx (canUndo, canRedo, HISTORY_DEPTH, HISTORY_NEW_GROUP_DELAY constants). Enhanced useToolbar to disable undo/redo buttons based on editor.can().undo()/redo() state. Updated Plugins barrel + public API exports. | Tiptap v3 StarterKit uses `undoRedo` key (not `history`); defaults already match plan values (100 / 500ms); CSS unchanged; ESM 35.95 KB (+0.55 KB) |
 
 <!--
 Example entries:

--- a/src/components/Plugins/HistoryPlugin.tsx
+++ b/src/components/Plugins/HistoryPlugin.tsx
@@ -1,1 +1,45 @@
-// Placeholder for History plugin
+/**
+ * History Plugin — undo/redo configuration and helpers.
+ *
+ * StarterKit includes the History extension by default. This plugin
+ * documents the configuration and provides helpers for history state.
+ *
+ * Configuration (via StarterKit in schema.ts):
+ * - depth: 100 (max undo steps stored)
+ * - newGroupDelay: 500ms (time before a new undo group is created)
+ *
+ * Keyboard shortcuts (provided by Tiptap History extension):
+ * - Undo: Ctrl/⌘+Z
+ * - Redo: Ctrl/⌘+Shift+Z or Ctrl/⌘+Y
+ *
+ * The `useHistory` hook (Phase 5) reads `canUndo`/`canRedo` state.
+ * The `useToolbar` hook syncs disabled state to undo/redo buttons.
+ */
+
+import type { Editor } from '@tiptap/core';
+
+/** Default history depth configured in schema.ts. */
+export const HISTORY_DEPTH = 100;
+
+/** Default new group delay (ms) configured in schema.ts. */
+export const HISTORY_NEW_GROUP_DELAY = 500;
+
+/**
+ * Check if the editor can currently undo.
+ *
+ * @param editor - Tiptap editor instance
+ * @returns true if there are steps to undo
+ */
+export function canUndo(editor: Editor): boolean {
+  return editor.can().undo();
+}
+
+/**
+ * Check if the editor can currently redo.
+ *
+ * @param editor - Tiptap editor instance
+ * @returns true if there are undone steps to redo
+ */
+export function canRedo(editor: Editor): boolean {
+  return editor.can().redo();
+}

--- a/src/components/Plugins/index.ts
+++ b/src/components/Plugins/index.ts
@@ -15,4 +15,9 @@ export {
   setCodeBlockLanguage,
   SUPPORTED_LANGUAGES,
 } from './CodeBlockPlugin';
-// Phase 14: HistoryPlugin
+export {
+  canUndo,
+  canRedo,
+  HISTORY_DEPTH,
+  HISTORY_NEW_GROUP_DELAY,
+} from './HistoryPlugin';

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -33,7 +33,11 @@ export function createExtensions(): Extensions {
     StarterKit.configure({
       // Phase 13 — disable StarterKit's codeBlock, replaced by CodeBlockLowlight
       codeBlock: false,
-      // history: false,      // Phase 14 — custom history config
+      // Phase 14 — configure history depth and grouping delay
+      undoRedo: {
+        depth: 100,
+        newGroupDelay: 500,
+      },
     }),
     Underline,
     Link.configure({

--- a/src/hooks/useToolbar.ts
+++ b/src/hooks/useToolbar.ts
@@ -157,7 +157,14 @@ export function useToolbar(toolbarItems: ToolbarItem[]): UseToolbarResult {
       if (item === '|') return '|';
 
       const meta = TOOLBAR_META[item];
-      const isDisabled = readOnly || !editor;
+      const baseDisabled = readOnly || !editor;
+
+      // Phase 14: undo/redo buttons are disabled based on history state
+      let isDisabled = baseDisabled;
+      if (!baseDisabled && editor) {
+        if (item === 'undo') isDisabled = !editor.can().undo();
+        if (item === 'redo') isDisabled = !editor.can().redo();
+      }
 
       return {
         id: item,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,3 +73,11 @@ export {
   setCodeBlockLanguage,
   SUPPORTED_LANGUAGES,
 } from './components/Plugins/CodeBlockPlugin';
+
+// History plugin utilities (advanced usage)
+export {
+  canUndo,
+  canRedo,
+  HISTORY_DEPTH,
+  HISTORY_NEW_GROUP_DELAY,
+} from './components/Plugins/HistoryPlugin';


### PR DESCRIPTION
- Configured StarterKit undoRedo: depth 100, newGroupDelay 500ms
- HistoryPlugin.tsx: canUndo, canRedo helpers, HISTORY_DEPTH and HISTORY_NEW_GROUP_DELAY constants
- Enhanced useToolbar: undo/redo buttons now disabled based on editor.can().undo()/redo() state (not just readOnly)
- Keyboard shortcuts provided by Tiptap: Ctrl/⌘+Z (undo), Ctrl/⌘+Shift+Z / Ctrl/⌘+Y (redo)
- Updated Plugins barrel + public API exports
- Bundle: 35.95 KB ESM / 38.27 KB CJS | CSS: 17.85 KB

# PR template

Please describe your changes and link any related issues.
