### PR TITLE
feat(phase-15): clipboard, paste handling & utilities

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 14 / 25 phases complete | **56% done**
+**Overall:** 15 / 25 phases complete | **60% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -31,7 +31,7 @@
 | 12 | Plugins: Images & Image Dialog | `Complete` | 2026-03-15 | 2026-03-15 | Image extension, ImagePlugin (URL + base64), accessible ImageDialog (drag-drop, preview), dialog.css extensions |
 | 13 | Plugins: Code Blocks & Syntax HL | `Complete` | 2026-03-15 | 2026-03-15 | CodeBlockLowlight + lowlight (common bundle), highlight.css (light GitHub + dark Catppuccin) |
 | 14 | Plugins: History (Undo / Redo) | `Complete` | 2026-03-15 | 2026-03-15 | StarterKit undoRedo configured (depth:100, newGroupDelay:500), undo/redo buttons disabled via canUndo/canRedo |
-| 15 | Clipboard, Paste Handling & Utilities | `Not Started` | — | — | |
+| 15 | Clipboard, Paste Handling & Utilities | `Complete` | 2026-03-15 | 2026-03-15 | dom.ts (sanitize, focus, selection), string.ts (URL, escape, shortcut), paste wired via transformPastedHTML |
 | 16 | Accessibility & Keyboard Navigation | `Not Started` | — | — | |
 | 17 | Playground App | `Not Started` | — | — | |
 | 18 | Storybook Setup & Stories | `Not Started` | — | — | |
@@ -51,7 +51,7 @@
 | **M2 — Type-safe foundation** | 3 | — | 2026-03-15 |
 | **M3 — Headless engine works** | 4–5 | — | — |
 | **M4 — Editor renders & types** | 6–8 | — | — |
-| **M5 — All features functional** | 9–16 | — | — |
+| **M5 — All features functional** | 9–16 | — | — |  <!-- Phase 16 remaining -->
 | **M6 — Demo-ready** | 17–19 | — | — |
 | **M7 — Fully tested** | 20–21 | — | — |
 | **M8 — Ship it** | 22–25 | — | — |
@@ -1754,10 +1754,10 @@ export { HistoryPlugin } from './HistoryPlugin';
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-15-clipboard-utils` |
 | **Blocked by** | Phases 9–14 |
 | **Deliverables** | `src/utils/dom.ts`, `src/utils/string.ts`, `src/utils/index.ts`, paste sanitization in engine |
 
@@ -1834,10 +1834,10 @@ editorProps: {
 
 ### Checkpoint
 
-- [ ] Pasting formatted text from external apps preserves formatting
-- [ ] Pasting a URL auto-creates a link
-- [ ] Script tags / event handlers in pasted content are stripped
-- [ ] All utility functions work correctly in isolation
+- [x] Pasting formatted text from external apps preserves formatting
+- [x] Pasting a URL auto-creates a link
+- [x] Script tags / event handlers in pasted content are stripped
+- [x] All utility functions work correctly in isolation
 
 ---
 
@@ -2983,6 +2983,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 12 | Installed @tiptap/extension-image (inline:false, allowBase64:true, loading:lazy). Added Image.configure to schema.ts. Created ImagePlugin.tsx (insertImageByUrl, insertImageBase64, readFileAsBase64, MAX_IMAGE_SIZE). Created ImageDialog.tsx (accessible modal: drag-drop zone, file upload with FileReader base64, URL input, alt text, preview thumbnail, 5MB warning). Extended dialog.css (dropzone, file info, separator, warning, preview). Wired ImageDialog into EditorWrapper. Updated all barrel exports + public API. | CSS 13.15 KB (+2.93 KB); ESM 33.95 KB (+10.49 KB) |
 | 2026-03-15 | 13 | Installed @tiptap/extension-code-block-lowlight + lowlight + @tiptap/extension-code-block + highlight.js (peers). Disabled StarterKit codeBlock, added CodeBlockLowlight.configure with lowlight (common bundle). Created CodeBlockPlugin.tsx (getCodeBlockLanguage, setCodeBlockLanguage, SUPPORTED_LANGUAGES). Created highlight.css (GitHub-like light + Catppuccin-inspired dark syntax colors for all hljs classes). Exported lowlight instance for consumer language registration. | CSS 17.85 KB (+4.70 KB); ESM 35.40 KB (+1.45 KB); language selector is exported helper, not a UI component yet |
 | 2026-03-15 | 14 | Configured StarterKit undoRedo (depth:100, newGroupDelay:500) in schema.ts. Created HistoryPlugin.tsx (canUndo, canRedo, HISTORY_DEPTH, HISTORY_NEW_GROUP_DELAY constants). Enhanced useToolbar to disable undo/redo buttons based on editor.can().undo()/redo() state. Updated Plugins barrel + public API exports. | Tiptap v3 StarterKit uses `undoRedo` key (not `history`); defaults already match plan values (100 / 500ms); CSS unchanged; ESM 35.95 KB (+0.55 KB) |
+| 2026-03-15 | 15 | Implemented dom.ts (sanitizeHTML with DOMParser recursive sanitizer — strips script/style/iframe/event handlers/javascript: URIs; getSelectionRect; focusFirstFocusable; trapFocus; isElementVisible). Implemented string.ts (isValidURL, escapeHTML, truncate, isMac, formatShortcut). Updated utils barrel. Wired transformPastedHTML in engine.ts. Added 10 util exports to public API. | CSS unchanged 17.85 KB; ESM 40.37 KB (+4.42 KB); DTS 19.09 KB (+3.63 KB from new exports) |
 
 <!--
 Example entries:

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1,5 +1,6 @@
 import { Editor } from '@tiptap/core';
 import { createExtensions } from './schema';
+import { sanitizeHTML } from '../utils/dom';
 
 /**
  * Options for creating a new editor instance.
@@ -32,6 +33,11 @@ export function createEditor(options: CreateEditorOptions = {}): Editor {
     extensions: createExtensions(),
     content: options.content || '',
     editable: options.editable ?? true,
+    editorProps: {
+      transformPastedHTML(html) {
+        return sanitizeHTML(html);
+      },
+    },
     onUpdate: ({ editor }) => {
       options.onUpdate?.(editor.getHTML());
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,3 +81,17 @@ export {
   HISTORY_DEPTH,
   HISTORY_NEW_GROUP_DELAY,
 } from './components/Plugins/HistoryPlugin';
+
+// DOM & string utilities (advanced usage)
+export {
+  sanitizeHTML,
+  getSelectionRect,
+  focusFirstFocusable,
+  trapFocus,
+  isElementVisible,
+  isValidURL,
+  escapeHTML,
+  truncate,
+  isMac,
+  formatShortcut,
+} from './utils';

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,1 +1,202 @@
-// Placeholder for DOM helpers
+/**
+ * DOM utility helpers.
+ *
+ * Provides HTML sanitization for pasted content, selection positioning,
+ * focus management for dialogs, and element visibility checks.
+ */
+
+// ── Dangerous tags & attributes ──────────────────────────────
+const DISALLOWED_TAGS = new Set([
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'applet',
+  'form',
+  'input',
+  'textarea',
+  'select',
+  'button',
+]);
+
+const EVENT_ATTR_RE = /^on/i;
+
+const DANGEROUS_ATTRS = new Set([
+  'srcdoc',
+  'formaction',
+  'xlink:href',
+]);
+
+// ── HTML Sanitization ────────────────────────────────────────
+
+/**
+ * Sanitize an HTML string by removing dangerous elements and attributes.
+ *
+ * Strips: `<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>`,
+ *         `<applet>`, `<form>`, form controls, event handlers (onclick, etc.),
+ *         `javascript:` URIs
+ *
+ * Allows: all formatting tags, links, images, lists, headings, code, tables
+ *
+ * Uses DOMParser for robust cross-browser parsing.
+ *
+ * @param html - Raw HTML string (e.g. from clipboard paste)
+ * @returns Sanitized HTML string safe for editor insertion
+ */
+export function sanitizeHTML(html: string): string {
+  if (!html) return '';
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  sanitizeNode(doc.body);
+
+  return doc.body.innerHTML;
+}
+
+/**
+ * Recursively sanitize a DOM node and its children.
+ */
+function sanitizeNode(node: Node): void {
+  const toRemove: Node[] = [];
+
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = node.childNodes[i];
+
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      const el = child as Element;
+      const tagName = el.tagName.toLowerCase();
+
+      // Remove disallowed tags entirely
+      if (DISALLOWED_TAGS.has(tagName)) {
+        toRemove.push(child);
+        continue;
+      }
+
+      // Remove dangerous attributes
+      const attrsToRemove: string[] = [];
+      for (let j = 0; j < el.attributes.length; j++) {
+        const attr = el.attributes[j];
+        const name = attr.name.toLowerCase();
+
+        if (
+          EVENT_ATTR_RE.test(name) ||
+          DANGEROUS_ATTRS.has(name) ||
+          isJavascriptURI(attr.value)
+        ) {
+          attrsToRemove.push(attr.name);
+        }
+      }
+      for (const attrName of attrsToRemove) {
+        el.removeAttribute(attrName);
+      }
+
+      // Recurse into allowed elements
+      sanitizeNode(child);
+    }
+  }
+
+  for (const child of toRemove) {
+    node.removeChild(child);
+  }
+}
+
+/**
+ * Check if a string is a javascript: URI.
+ */
+function isJavascriptURI(value: string): boolean {
+  return /^\s*javascript\s*:/i.test(value);
+}
+
+// ── Selection helpers ────────────────────────────────────────
+
+/**
+ * Get the bounding rectangle of the current browser selection.
+ *
+ * Useful for positioning floating toolbars or dialogs near the cursor.
+ *
+ * @returns DOMRect of the selection, or null if nothing is selected
+ */
+export function getSelectionRect(): DOMRect | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+
+  // Collapsed selection at start of line can return a zero-width rect
+  if (rect.width === 0 && rect.height === 0) return null;
+
+  return rect;
+}
+
+// ── Focus management ─────────────────────────────────────────
+
+/** Selector for focusable elements. */
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Focus the first focusable element inside a container.
+ *
+ * @param container - DOM element to search within
+ */
+export function focusFirstFocusable(container: HTMLElement): void {
+  const first = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+  first?.focus();
+}
+
+/**
+ * Set up focus trapping within a container element.
+ *
+ * Focus wraps from the last focusable element back to the first (and vice versa).
+ * Returns a cleanup function to remove the event listener.
+ *
+ * @param container - DOM element to trap focus within
+ * @returns Cleanup function to stop trapping
+ */
+export function trapFocus(container: HTMLElement): () => void {
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+
+    const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  container.addEventListener('keydown', handleKeyDown);
+  return () => container.removeEventListener('keydown', handleKeyDown);
+}
+
+// ── Visibility ───────────────────────────────────────────────
+
+/**
+ * Check if an element is visible in the viewport.
+ *
+ * An element is considered visible if it has non-zero dimensions
+ * and is not hidden via CSS.
+ *
+ * @param el - Element to check
+ * @returns true if the element is visible
+ */
+export function isElementVisible(el: HTMLElement): boolean {
+  if (el.offsetWidth === 0 && el.offsetHeight === 0) return false;
+
+  const style = getComputedStyle(el);
+  return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,5 @@
-// Utils public exports
+/**
+ * Utils barrel — re-exports DOM and string helpers.
+ */
+export { sanitizeHTML, getSelectionRect, focusFirstFocusable, trapFocus, isElementVisible } from './dom';
+export { isValidURL, escapeHTML, truncate, isMac, formatShortcut } from './string';

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,1 +1,128 @@
-// Placeholder for string helpers
+/**
+ * String utility helpers.
+ *
+ * Provides URL validation, HTML escaping, text truncation,
+ * platform detection, and keyboard shortcut formatting.
+ */
+
+// ── URL Validation ───────────────────────────────────────────
+
+/**
+ * Validate that a string is a well-formed URL.
+ *
+ * Accepts http(s), mailto, tel, relative paths (/...), and anchors (#...).
+ *
+ * @param str - String to validate
+ * @returns true if the string is a valid URL format
+ */
+export function isValidURL(str: string): boolean {
+  if (!str || !str.trim()) return false;
+  const trimmed = str.trim();
+
+  // Relative paths and anchors
+  if (/^(\/|#)/.test(trimmed)) return true;
+
+  // Standard protocols
+  if (/^(https?:\/\/|mailto:|tel:)/.test(trimmed)) {
+    try {
+      new URL(trimmed);
+      return true;
+    } catch {
+      // mailto: and tel: may not parse as URL, accept if they match the prefix
+      return /^(mailto:|tel:)/.test(trimmed);
+    }
+  }
+
+  return false;
+}
+
+// ── HTML Escaping ────────────────────────────────────────────
+
+/** Map of characters to their HTML entity equivalents. */
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+};
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+
+/**
+ * Escape special HTML characters for safe interpolation into HTML strings.
+ *
+ * @param str - Raw string
+ * @returns Escaped string safe for HTML insertion
+ */
+export function escapeHTML(str: string): string {
+  if (!str) return '';
+  return str.replace(HTML_ESCAPE_RE, (char) => HTML_ESCAPE_MAP[char] ?? char);
+}
+
+// ── Truncation ───────────────────────────────────────────────
+
+/**
+ * Truncate a string to a maximum length, appending an ellipsis if truncated.
+ *
+ * @param str    - String to truncate
+ * @param length - Maximum length (including ellipsis)
+ * @returns Truncated string
+ */
+export function truncate(str: string, length: number): string {
+  if (!str || str.length <= length) return str ?? '';
+  if (length <= 3) return str.slice(0, length);
+  return str.slice(0, length - 3) + '...';
+}
+
+// ── Platform Detection ───────────────────────────────────────
+
+/**
+ * Detect if the current platform is macOS.
+ *
+ * Uses `navigator.platform` (deprecated but widely supported) with
+ * a fallback to `navigator.userAgentData` where available.
+ *
+ * @returns true on macOS/iOS
+ */
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+
+  // Modern API (Chromium-based browsers)
+  const uaData = (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData;
+  if (uaData?.platform) {
+    return /mac/i.test(uaData.platform);
+  }
+
+  // Legacy fallback
+  return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+// ── Shortcut Formatting ──────────────────────────────────────
+
+/**
+ * Format a keyboard shortcut string for display.
+ *
+ * Replaces `Mod` with `⌘` on Mac or `Ctrl` on other platforms.
+ * Replaces `+` separators with platform-appropriate formatting.
+ *
+ * @param key - Shortcut descriptor (e.g. 'Mod+B', 'Mod+Shift+Z')
+ * @returns Formatted shortcut string (e.g. '⌘B', 'Ctrl+Shift+Z')
+ *
+ * @example
+ * formatShortcut('Mod+B') // '⌘B' on Mac, 'Ctrl+B' on Windows
+ * formatShortcut('Mod+Shift+Z') // '⌘⇧Z' on Mac, 'Ctrl+Shift+Z' on Windows
+ */
+export function formatShortcut(key: string): string {
+  const mac = isMac();
+
+  if (mac) {
+    return key
+      .replace(/Mod\+/g, '⌘')
+      .replace(/Shift\+/g, '⇧')
+      .replace(/Alt\+/g, '⌥')
+      .replace(/\+/g, '');
+  }
+
+  return key.replace(/Mod\+/g, 'Ctrl+');
+}


### PR DESCRIPTION
- Implement src/utils/dom.ts: sanitizeHTML (DOMParser recursive sanitizer, strips script/style/iframe/event handlers/javascript: URIs), getSelectionRect, focusFirstFocusable, trapFocus, isElementVisible
- Implement src/utils/string.ts: isValidURL, escapeHTML, truncate, isMac, formatShortcut (⌘/Ctrl platform-aware)
- Update src/utils/index.ts barrel with all exports
- Wire transformPastedHTML in engine.ts for paste sanitization
- Export 10 utility functions from public API (src/index.ts)
- Update IMPLEMENTATION_PLAN.md: 15/25 (60%)

Build: ESM 40.37 KB | CJS 42.91 KB | CSS 17.85 KB | DTS 19.09 KB

# PR template

Please describe your changes and link any related issues.
