### PR TITLE
feat(examples): React + Next.js demo apps with code-split components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,19 +19,27 @@ examples/*/yarn.lock
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+**/.yarn/*
+!**/.yarn/patches
+!**/.yarn/plugins
+!**/.yarn/releases
+!**/.yarn/sdks
+!**/.yarn/versions
 
 # testing
 /coverage
 
 # next.js
-/.next/
+.next/
+**/.next/
 /out/
 
 # production
 /build
 
 # Build output
-/dist
+dist/
+*/dist/
 
 # Storybook
 /storybook-static

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -14,7 +14,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 18 / 25 phases complete | **72% done**
+**Overall:** 19 / 25 phases complete | **76% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -39,7 +39,7 @@
 | 16 | Accessibility & Keyboard Navigation | `Complete` | 2026-03-15 | 2026-03-15 | Roving tabindex, ARIA attrs on editor/toolbar/dialogs, focus restoration, ariaLabel prop |
 | 17 | Playground App | `Complete` | 2026-03-15 | 2026-03-15 | Vite 6.4.1, React 19, link:../ for local pkg, 4 toolbar presets, theme/readOnly toggle, HTML output panel |
 | 18 | Storybook Setup & Stories | `Complete` | 2026-03-15 | 2026-03-15 | Storybook 8.6.18 (all packages aligned); 3 story files (18 stories total) |
-| 19 | Example Apps (React & Next.js) | `Not Started` | — | — | |
+| 19 | Example Apps (React & Next.js) | `Complete` | 2026-03-15 | 2026-03-15 | React demo (Vite blog editor), Next.js 14 demo (SSR-safe dynamic import); code-split components |
 | 20 | Unit & Integration Tests | `Not Started` | — | — | |
 | 21 | End-to-End Tests | `Not Started` | — | — | |
 | 22 | Documentation | `Not Started` | — | — | |
@@ -56,7 +56,7 @@
 | **M3 — Headless engine works** | 4–5 | — | — |
 | **M4 — Editor renders & types** | 6–8 | — | — |
 | **M5 — All features functional** | 9–16 | — | 2026-03-15 |
-| **M6 — Demo-ready** | 17–19 | — | — |
+| **M6 — Demo-ready** | 17–19 | — | 2026-03-15 |
 | **M7 — Fully tested** | 20–21 | — | — |
 | **M8 — Ship it** | 22–25 | — | — |
 
@@ -2120,10 +2120,10 @@ Each story uses Storybook Controls for interactive prop manipulation.
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-19-example-apps` |
 | **Blocked by** | Phase 16 (parallelizable with 17, 18) |
 | **Deliverables** | `examples/react-demo/` fully functional, `examples/nextjs-demo/` fully functional |
 
@@ -2177,10 +2177,10 @@ const RichTextEditor = dynamic(
 
 ### Checkpoint
 
-- [ ] `cd examples/react-demo && yarn install && yarn dev` works
-- [ ] `cd examples/nextjs-demo && yarn install && yarn dev` works
-- [ ] Editor is fully functional in both environments
-- [ ] Next.js demo handles SSR correctly (no hydration errors)
+- [x] `cd examples/react-demo && yarn install && yarn dev` works
+- [x] `cd examples/nextjs-demo && yarn install && yarn dev` works
+- [x] Editor is fully functional in both environments
+- [x] Next.js demo handles SSR correctly (no hydration errors)
 
 ---
 
@@ -2991,6 +2991,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 16 | Enhanced Toolbar with proper roving tabindex (only one button has tabindex=0, rest -1; arrow keys move + update tracked roving id). Added aria-disabled to ToolbarButton. Added ARIA attributes to editor content area via editorProps.attributes (role=textbox, aria-multiline, aria-label, aria-placeholder, aria-readonly). Added ariaLabel prop flowing through RichTextEditor → EditorProvider → useEditor → createEditor. Added focus restoration to dialogs (triggerRef saves activeElement on mount, restores on close via requestAnimationFrame). Synced aria-readonly with readOnly prop changes. Milestone M5 reached. | CSS unchanged 17.85 KB; ESM 42.04 KB (+1.67 KB); DTS 19.37 KB (+0.28 KB from ariaLabel prop) |
 | 2026-03-15 | 17 | Created Vite 6.4.1 playground with React 19. package.json with link:../ for local pkg. index.html, tsconfig.json, vite.config.ts. main.tsx (createRoot). App.tsx: 4 toolbar presets (full/minimal/writing/code), theme toggle (light↔dark), read-only toggle, HTML output panel with show/hide, sample content, responsive layout. Standalone yarn.lock for separate Yarn project. Updated .gitignore for playground/examples node_modules. | Deviated from plan: React 19 (not 18) to match root project; dropped JSON panel (Tiptap JSON requires editor instance, not in public scope); added separate yarn.lock for Yarn 4 Berry standalone project |
 | 2026-03-15 | 18 | Installed Storybook 8.6.18 (aligned all 5 packages). Created .storybook/main.ts (react-vite framework, stories glob, react-docgen-typescript). Created .storybook/preview.ts (CSS import, layout padded, controls matchers). Wrote RichTextEditor.stories.tsx (8 stories: Default, WithInitialContent, CustomToolbar, ReadOnly, WithPlaceholder, MinMaxHeight, Controlled, FullFeatured). Wrote Toolbar.stories.tsx (5 stories: AllItems, Minimal, WithHeadings, DisabledState, CustomGroups). Wrote Themes.stories.tsx (4 stories: LightTheme, DarkTheme, SideBySide, ThemeToggle). build-storybook produces static output (371 modules, 8.59s). | Initially installed storybook v10 (latest) mixed with v8 addons — removed & reinstalled all at ^8.6.0 for alignment; Vite peer dep warning (project has v8, Storybook wants ^6) is cosmetic only |
+| 2026-03-15 | 19 | React demo: Vite 6 + React 19 blog post editor with code-split components (Header, Preview, HtmlOutput), CSS stylesheet (data-theme selectors), constants file, title input, theme toggle, preview mode, save button, HTML output. Next.js 14 demo: Pages Router, dynamic import with ssr:false + loading placeholder, transpilePackages config, Header/HtmlOutput components, theme toggle. Both install & dev/build verified. Milestone M6 reached. | Used React 19 (not 18) for both; Next.js 14 peer dep warnings with React 19 are cosmetic; ESLint ignoreDuringBuilds needed (root ESLint 9 flat config incompatible with Next.js 14 built-in lint); code-split per user request instead of single-file approach |
 
 <!--
 Example entries:

--- a/examples/nextjs-demo/README.md
+++ b/examples/nextjs-demo/README.md
@@ -1,3 +1,52 @@
-Placeholder for a Next.js example to validate SSR compatibility (optional).
+# Next.js Demo — SSR-Compatible Editor
 
-Create this example when you need to test server-rendered usage.
+A Next.js 14 (Pages Router) example demonstrating that `rich-text-editor-ndevu` works correctly in a server-rendered context.
+
+## Key Technique
+
+The editor uses `contentEditable`, which is browser-only. We use `next/dynamic` with `ssr: false` to avoid SSR hydration errors:
+
+```tsx
+const RichTextEditor = dynamic(
+  () => import('rich-text-editor-ndevu').then((mod) => mod.RichTextEditor),
+  { ssr: false, loading: () => <div>Loading editor…</div> },
+);
+```
+
+## Features
+
+- **Dynamic import** with loading placeholder
+- **Theme toggle** (light / dark)
+- **Raw HTML** output panel
+- **`transpilePackages`** configured in `next.config.js`
+
+## Getting Started
+
+```bash
+cd examples/nextjs-demo
+yarn install
+yarn dev        # opens http://localhost:3001
+```
+
+## Project Structure
+
+```
+pages/
+  _app.tsx             # Global CSS import
+  index.tsx            # Home page with dynamic editor import
+src/
+  components/
+    Header.tsx         # Page header with theme toggle
+    HtmlOutput.tsx     # Collapsible raw HTML output
+    index.ts           # Barrel export
+  styles/
+    app.css            # All styles (theme-aware via data-theme)
+  utils/
+    constants.ts       # INITIAL_CONTENT
+next.config.js         # transpilePackages + eslint.ignoreDuringBuilds
+```
+
+## Notes
+
+- **React 19 + Next.js 14**: Peer dep warnings are expected; works at runtime.
+- **ESLint**: Skipped during `next build` because the root project uses ESLint 9 flat config, which is incompatible with Next.js 14's built-in ESLint integration.

--- a/examples/nextjs-demo/next.config.js
+++ b/examples/nextjs-demo/next.config.js
@@ -1,1 +1,12 @@
-// Next.js config placeholder
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['rich-text-editor-ndevu'],
+  eslint: {
+    // The root project uses ESLint 9 flat config which is incompatible
+    // with Next.js 14's built-in ESLint integration. Skip during build.
+    ignoreDuringBuilds: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/examples/nextjs-demo/package.json
+++ b/examples/nextjs-demo/package.json
@@ -1,1 +1,22 @@
-{}
+{
+  "name": "nextjs-demo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3001",
+    "build": "next build",
+    "start": "next start -p 3001"
+  },
+  "dependencies": {
+    "next": "^14.2.29",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "rich-text-editor-ndevu": "link:../../"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/nextjs-demo/pages/_app.tsx
+++ b/examples/nextjs-demo/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../src/styles/app.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/examples/nextjs-demo/pages/index.tsx
+++ b/examples/nextjs-demo/pages/index.tsx
@@ -1,1 +1,45 @@
-// Placeholder Next.js page
+import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import type { Theme } from 'rich-text-editor-ndevu';
+import { DEFAULT_TOOLBAR } from 'rich-text-editor-ndevu';
+import { Header, HtmlOutput } from '../src/components';
+import { INITIAL_CONTENT } from '../src/utils/constants';
+
+/**
+ * Dynamic import with ssr: false — contentEditable doesn't work server-side.
+ * The loading fallback prevents layout shift while the editor JS loads.
+ */
+const RichTextEditor = dynamic(
+  () => import('rich-text-editor-ndevu').then((mod) => mod.RichTextEditor),
+  {
+    ssr: false,
+    loading: () => <div className="editor-loading">Loading editor…</div>,
+  },
+);
+
+export default function HomePage() {
+  const [content, setContent] = useState(INITIAL_CONTENT);
+  const [theme, setTheme] = useState<Theme>('light');
+
+  const toggleTheme = useCallback(() => setTheme((t) => (t === 'light' ? 'dark' : 'light')), []);
+
+  return (
+    <div className="app" data-theme={theme}>
+      <Header theme={theme} onToggleTheme={toggleTheme} />
+
+      <main className="main">
+        <RichTextEditor
+          value={content}
+          onChange={setContent}
+          theme={theme}
+          toolbar={DEFAULT_TOOLBAR}
+          placeholder="Start writing…"
+          minHeight="250px"
+          ariaLabel="Next.js editor demo"
+        />
+
+        <HtmlOutput html={content} />
+      </main>
+    </div>
+  );
+}

--- a/examples/nextjs-demo/src/components/Header.tsx
+++ b/examples/nextjs-demo/src/components/Header.tsx
@@ -1,0 +1,21 @@
+import type { Theme } from 'rich-text-editor-ndevu';
+
+interface HeaderProps {
+  theme: Theme;
+  onToggleTheme: () => void;
+}
+
+export function Header({ theme, onToggleTheme }: HeaderProps) {
+  const isDark = theme === 'dark';
+
+  return (
+    <header className="header">
+      <h1 className="header__title">📝 Next.js Editor Demo</h1>
+      <div className="header__actions">
+        <button className="btn" onClick={onToggleTheme}>
+          {isDark ? '☀️ Light' : '🌙 Dark'}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/examples/nextjs-demo/src/components/HtmlOutput.tsx
+++ b/examples/nextjs-demo/src/components/HtmlOutput.tsx
@@ -1,0 +1,12 @@
+interface HtmlOutputProps {
+  html: string;
+}
+
+export function HtmlOutput({ html }: HtmlOutputProps) {
+  return (
+    <details className="html-output">
+      <summary className="html-output__summary">Raw HTML</summary>
+      <pre className="html-output__code">{html}</pre>
+    </details>
+  );
+}

--- a/examples/nextjs-demo/src/components/index.ts
+++ b/examples/nextjs-demo/src/components/index.ts
@@ -1,0 +1,2 @@
+export { Header } from './Header';
+export { HtmlOutput } from './HtmlOutput';

--- a/examples/nextjs-demo/src/styles/app.css
+++ b/examples/nextjs-demo/src/styles/app.css
@@ -1,0 +1,140 @@
+/* ── Reset & Layout ─────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+}
+
+/* ── App Shell ──────────────────────────────── */
+.app {
+  min-height: 100vh;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.app[data-theme='light'] {
+  background-color: #f8f9fa;
+  color: #1a1a1a;
+}
+
+.app[data-theme='dark'] {
+  background-color: #1a1b26;
+  color: #c0caf5;
+}
+
+/* ── Header ─────────────────────────────────── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+}
+
+[data-theme='light'] .header {
+  border-bottom: 1px solid #dee2e6;
+}
+
+[data-theme='dark'] .header {
+  border-bottom: 1px solid #2f3348;
+}
+
+.header__title {
+  font-size: 1.25rem;
+}
+
+.header__actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ── Buttons ────────────────────────────────── */
+.btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+[data-theme='light'] .btn {
+  border: 1px solid #ced4da;
+  background-color: #fff;
+  color: #1a1a1a;
+}
+
+[data-theme='light'] .btn:hover {
+  background-color: #f1f3f5;
+}
+
+[data-theme='dark'] .btn {
+  border: 1px solid #3b3e52;
+  background-color: #24283b;
+  color: #c0caf5;
+}
+
+[data-theme='dark'] .btn:hover {
+  background-color: #2f3348;
+}
+
+/* ── Main Content ───────────────────────────── */
+.main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* ── Editor Loading ─────────────────────────── */
+.editor-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+[data-theme='light'] .editor-loading {
+  border: 1px solid #dee2e6;
+  background-color: #f8f9fa;
+  color: #868e96;
+}
+
+[data-theme='dark'] .editor-loading {
+  border: 1px solid #2f3348;
+  background-color: #24283b;
+  color: #565f89;
+}
+
+/* ── HTML Output ────────────────────────────── */
+.html-output {
+  margin-top: 24px;
+}
+
+.html-output__summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.html-output__code {
+  margin-top: 8px;
+  padding: 12px;
+  border-radius: 6px;
+  overflow: auto;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+[data-theme='light'] .html-output__code {
+  background-color: #f1f3f5;
+}
+
+[data-theme='dark'] .html-output__code {
+  background-color: #24283b;
+}

--- a/examples/nextjs-demo/src/utils/constants.ts
+++ b/examples/nextjs-demo/src/utils/constants.ts
@@ -1,0 +1,8 @@
+export const INITIAL_CONTENT = `
+<h2>Hello from Next.js!</h2>
+<p>This editor is loaded with <code>ssr: false</code> to avoid hydration issues with contentEditable.</p>
+<ul>
+  <li>Works with Pages Router</li>
+  <li>Uses <code>next/dynamic</code> for client-only loading</li>
+</ul>
+`.trim();

--- a/examples/nextjs-demo/tsconfig.json
+++ b/examples/nextjs-demo/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/examples/react-demo/README.md
+++ b/examples/react-demo/README.md
@@ -1,3 +1,36 @@
-Minimal React demo demonstrating `RichTextEditor` usage with Vite.
+# React Demo — Blog Post Editor
 
-This is a lightweight example to exercise the library during development.
+A Vite + React example showing `rich-text-editor-ndevu` in a realistic blog-post editing scenario.
+
+## Features
+
+- **Title input** + rich text body editor
+- **Theme toggle** (light / dark)
+- **Live preview** — render the HTML output as a formatted article
+- **Save button** — logs the payload to the console
+- **Raw HTML** — collapsible `<details>` showing the editor's HTML
+
+## Getting Started
+
+```bash
+cd examples/react-demo
+yarn install
+yarn dev        # opens http://localhost:5174
+```
+
+## Project Structure
+
+```
+src/
+  components/
+    Header.tsx         # Top bar with theme/preview/save buttons
+    Preview.tsx        # Read-only HTML preview panel
+    HtmlOutput.tsx     # Collapsible raw HTML output
+    index.ts           # Barrel export
+  styles/
+    app.css            # All styles (theme-aware via data-theme)
+  utils/
+    constants.ts       # INITIAL_CONTENT
+  App.tsx              # Root composition (state only, no inline styles)
+  main.tsx             # React 19 entry point
+```

--- a/examples/react-demo/index.html
+++ b/examples/react-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Demo — Rich Text Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-demo/package.json
+++ b/examples/react-demo/package.json
@@ -1,1 +1,23 @@
-{}
+{
+  "name": "react-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "rich-text-editor-ndevu": "link:../../"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/examples/react-demo/src/App.tsx
+++ b/examples/react-demo/src/App.tsx
@@ -1,1 +1,61 @@
-// Placeholder React demo App
+import { useState, useCallback } from 'react';
+import { RichTextEditor, DEFAULT_TOOLBAR } from 'rich-text-editor-ndevu';
+import type { Theme } from 'rich-text-editor-ndevu';
+import { Header, Preview, HtmlOutput } from './components';
+import { INITIAL_CONTENT } from './utils/constants';
+import './styles/app.css';
+
+export default function App() {
+  const [title, setTitle] = useState('Untitled Post');
+  const [body, setBody] = useState(INITIAL_CONTENT);
+  const [theme, setTheme] = useState<Theme>('light');
+  const [showPreview, setShowPreview] = useState(false);
+
+  const toggleTheme = useCallback(() => setTheme((t) => (t === 'light' ? 'dark' : 'light')), []);
+  const togglePreview = useCallback(() => setShowPreview((p) => !p), []);
+
+  const handleSave = useCallback(() => {
+    const payload = { title, body, savedAt: new Date().toISOString() };
+    // eslint-disable-next-line no-console
+    console.log('[Save]', payload);
+    alert('Saved! Check the console for the payload.');
+  }, [title, body]);
+
+  return (
+    <div className="app" data-theme={theme}>
+      <Header
+        theme={theme}
+        showPreview={showPreview}
+        onToggleTheme={toggleTheme}
+        onTogglePreview={togglePreview}
+        onSave={handleSave}
+      />
+
+      <main className="main">
+        <input
+          className="title-input"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Post title…"
+        />
+
+        {showPreview ? (
+          <Preview title={title} body={body} />
+        ) : (
+          <RichTextEditor
+            value={body}
+            onChange={setBody}
+            theme={theme}
+            toolbar={DEFAULT_TOOLBAR}
+            placeholder="Write your blog post…"
+            minHeight="300px"
+            ariaLabel="Blog post body"
+          />
+        )}
+
+        <HtmlOutput html={body} />
+      </main>
+    </div>
+  );
+}

--- a/examples/react-demo/src/components/Header.tsx
+++ b/examples/react-demo/src/components/Header.tsx
@@ -1,0 +1,37 @@
+import type { Theme } from 'rich-text-editor-ndevu';
+
+interface HeaderProps {
+  theme: Theme;
+  showPreview: boolean;
+  onToggleTheme: () => void;
+  onTogglePreview: () => void;
+  onSave: () => void;
+}
+
+export function Header({
+  theme,
+  showPreview,
+  onToggleTheme,
+  onTogglePreview,
+  onSave,
+}: HeaderProps) {
+  const isDark = theme === 'dark';
+
+  return (
+    <header className="header">
+      <h1 className="header__title">📝 Blog Post Editor</h1>
+
+      <div className="header__actions">
+        <button className="btn" onClick={onToggleTheme}>
+          {isDark ? '☀️ Light' : '🌙 Dark'}
+        </button>
+        <button className="btn" onClick={onTogglePreview}>
+          {showPreview ? '✏️ Edit' : '👁 Preview'}
+        </button>
+        <button className="btn btn--primary" onClick={onSave}>
+          💾 Save
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/examples/react-demo/src/components/HtmlOutput.tsx
+++ b/examples/react-demo/src/components/HtmlOutput.tsx
@@ -1,0 +1,12 @@
+interface HtmlOutputProps {
+  html: string;
+}
+
+export function HtmlOutput({ html }: HtmlOutputProps) {
+  return (
+    <details className="html-output">
+      <summary className="html-output__summary">Raw HTML</summary>
+      <pre className="html-output__code">{html}</pre>
+    </details>
+  );
+}

--- a/examples/react-demo/src/components/Preview.tsx
+++ b/examples/react-demo/src/components/Preview.tsx
@@ -1,0 +1,13 @@
+interface PreviewProps {
+  title: string;
+  body: string;
+}
+
+export function Preview({ title, body }: PreviewProps) {
+  return (
+    <article className="preview">
+      <h1 className="preview__title">{title || 'Untitled'}</h1>
+      <div dangerouslySetInnerHTML={{ __html: body }} />
+    </article>
+  );
+}

--- a/examples/react-demo/src/components/index.ts
+++ b/examples/react-demo/src/components/index.ts
@@ -1,0 +1,3 @@
+export { Header } from './Header';
+export { Preview } from './Preview';
+export { HtmlOutput } from './HtmlOutput';

--- a/examples/react-demo/src/main.tsx
+++ b/examples/react-demo/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-demo/src/styles/app.css
+++ b/examples/react-demo/src/styles/app.css
@@ -1,0 +1,169 @@
+/* ── Reset & Layout ─────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+}
+
+/* ── App Shell ──────────────────────────────── */
+.app {
+  min-height: 100vh;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.app[data-theme='light'] {
+  background-color: #f8f9fa;
+  color: #1a1a1a;
+}
+
+.app[data-theme='dark'] {
+  background-color: #1a1b26;
+  color: #c0caf5;
+}
+
+/* ── Header ─────────────────────────────────── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+}
+
+[data-theme='light'] .header {
+  border-bottom: 1px solid #dee2e6;
+}
+
+[data-theme='dark'] .header {
+  border-bottom: 1px solid #2f3348;
+}
+
+.header__title {
+  font-size: 1.25rem;
+}
+
+.header__actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ── Buttons ────────────────────────────────── */
+.btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.btn--primary {
+  font-weight: 600;
+}
+
+[data-theme='light'] .btn {
+  border: 1px solid #ced4da;
+  background-color: #fff;
+  color: #1a1a1a;
+}
+
+[data-theme='light'] .btn:hover {
+  background-color: #f1f3f5;
+}
+
+[data-theme='dark'] .btn {
+  border: 1px solid #3b3e52;
+  background-color: #24283b;
+  color: #c0caf5;
+}
+
+[data-theme='dark'] .btn:hover {
+  background-color: #2f3348;
+}
+
+/* ── Main Content ───────────────────────────── */
+.main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* ── Title Input ────────────────────────────── */
+.title-input {
+  width: 100%;
+  font-size: 1.75rem;
+  font-weight: 700;
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  padding: 8px 0;
+  margin-bottom: 20px;
+  outline: none;
+  font-family: inherit;
+}
+
+[data-theme='light'] .title-input {
+  border-bottom: 2px solid #dee2e6;
+}
+
+[data-theme='dark'] .title-input {
+  border-bottom: 2px solid #3b3e52;
+}
+
+.title-input:focus {
+  border-bottom-color: #4c6ef5;
+}
+
+/* ── Preview Panel ──────────────────────────── */
+.preview {
+  padding: 24px;
+  border-radius: 8px;
+  line-height: 1.7;
+}
+
+.preview__title {
+  margin-top: 0;
+}
+
+[data-theme='light'] .preview {
+  border: 1px solid #dee2e6;
+  background-color: #fff;
+}
+
+[data-theme='dark'] .preview {
+  border: 1px solid #2f3348;
+  background-color: #24283b;
+}
+
+/* ── HTML Output ────────────────────────────── */
+.html-output {
+  margin-top: 24px;
+}
+
+.html-output__summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.html-output__code {
+  margin-top: 8px;
+  padding: 12px;
+  border-radius: 6px;
+  overflow: auto;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+[data-theme='light'] .html-output__code {
+  background-color: #f1f3f5;
+}
+
+[data-theme='dark'] .html-output__code {
+  background-color: #24283b;
+}

--- a/examples/react-demo/src/utils/constants.ts
+++ b/examples/react-demo/src/utils/constants.ts
@@ -1,0 +1,4 @@
+export const INITIAL_CONTENT = `
+<h2>My First Blog Post</h2>
+<p>Start writing your post here…</p>
+`.trim();

--- a/examples/react-demo/tsconfig.json
+++ b/examples/react-demo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/react-demo/vite.config.ts
+++ b/examples/react-demo/vite.config.ts
@@ -1,1 +1,10 @@
-// Vite config placeholder
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5174,
+    open: true,
+  },
+});

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,1 +1,0 @@
-// Storybook main placeholder

--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -1,1 +1,0 @@
-// Storybook preview placeholder


### PR DESCRIPTION
Phase 19 — Example Apps (React Demo & Next.js Demo)

React demo (examples/react-demo/):
- Vite 6 + React 19 blog post editor
- Code-split: Header, Preview, HtmlOutput components
- CSS stylesheet with data-theme selectors (zero inline styles)
- Title input, theme toggle, preview mode, save, HTML output

Next.js demo (examples/nextjs-demo/):
- Next.js 14 Pages Router with dynamic import (ssr: false)
- Loading placeholder for editor while JS loads
- transpilePackages + eslint.ignoreDuringBuilds config
- Code-split: Header, HtmlOutput components
- Verified: next build succeeds, dev server compiles (200 OK)

Also:
- Fix .gitignore: exclude **/.yarn/*, .next/, dist/ at all levels
- Remove storybook/.storybook/ (moved to .storybook/ in Phase 18)
- Milestone M6 (Demo-ready) reached
