### PR TITLE
chore(phase-24): implement build scripts and release pipeline

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -14,7 +14,7 @@
 
 ## Progress Dashboard
 
-**Overall:** 22 / 25 phases complete | **88% done**
+**Overall:** 23 / 25 phases complete | **92% done**
 
 > Update the table below as each phase progresses. Use the status markers:
 > `Not Started`, `In Progress`, `Blocked`, `Complete`, `Skipped`
@@ -44,7 +44,7 @@
 | 21 | End-to-End Tests | `Not Started` | — | — | Deferred to after remaining phases |
 | 22 | Documentation | `Complete` | 2026-03-15 | 2026-03-15 | 5 docs files, CONTRIBUTING.md, CHANGELOG.md |
 | 23 | CI / CD Pipelines | `Complete` | 2026-03-15 | 2026-03-15 | ci.yml (3 jobs), release.yml (npm provenance), YAML issue templates, PR template |
-| 24 | Build Scripts & Release Pipeline | `Not Started` | — | — | |
+| 24 | Build Scripts & Release Pipeline | `Complete` | 2026-03-15 | 2026-03-15 | clean.ts (--all flag), build.ts (clean→typecheck→tsup→verify), release.ts (bump→tag→push) |
 | 25 | Final Polish & v0.1.0 Release | `Not Started` | — | — | |
 
 ### Milestone Markers
@@ -2584,10 +2584,10 @@ Expand with:
 
 | | |
 |---|---|
-| **Status** | `Not Started` |
-| **Started** | — |
-| **Completed** | — |
-| **Branch** | — |
+| **Status** | `Complete` |
+| **Started** | 2026-03-15 |
+| **Completed** | 2026-03-15 |
+| **Branch** | `feat/phase-24-build-scripts` |
 | **Blocked by** | Phase 23 |
 | **Deliverables** | `scripts/clean.ts`, `scripts/build.ts`, `scripts/release.ts` |
 
@@ -2640,9 +2640,9 @@ console.log('Build completed successfully!');
 
 ### Checkpoint
 
-- [ ] `yarn clean` removes all build artifacts
-- [ ] `tsx scripts/build.ts` produces a valid `dist/` directory
-- [ ] Release script works end-to-end (dry run)
+- [x] `yarn clean` removes all build artifacts
+- [x] `tsx scripts/build.ts` produces a valid `dist/` directory
+- [x] Release script works end-to-end (dry run)
 
 ---
 
@@ -2995,6 +2995,7 @@ Chronological record of implementation progress. Add entries as work is done.
 | 2026-03-15 | 22 | Documentation: architecture.md (hierarchy, data flow, extension system, directory rationale, decision log), api.md (full props/hooks/commands/types/constants reference), plugins.md (built-in plugins, custom plugin guide), theming.md (all 32 CSS tokens, custom theme guide), contributing.md (detailed dev guide), CONTRIBUTING.md (concise quick-start), CHANGELOG.md (v0.1.0 features) | Phase 21 (E2E) deferred by user decision; proceeded to Phase 22 directly |
 | 2026-03-15 | 20 | Unit & integration tests: 12 test files, 182 tests all passing. Coverage: stmts 84.8%, branches 75.4%, funcs 88%, lines 87.6%. Tested: engine, commands (18 cmds), Editor component, Toolbar (buttons, keyboard, a11y), useEditor/useToolbar/useHistory hooks, dom utils, string utils, content Parser/Serializer, model, all Plugins, both Dialogs (LinkDialog + ImageDialog with validation, submit, Escape, overlay click, drag-drop). | Added 6 additional test files beyond the 6 planned (model, Content, Plugins, Dialogs, useToolbar, useHistory) to meet 80% coverage thresholds; jsdom limitations prevented getBoundingClientRect tests |
 | 2026-03-15 | 23 | CI/CD pipelines: ci.yml (lint+typecheck, test+coverage, build+verify — 3 parallel jobs, Node 20, Corepack, concurrency groups), release.yml (npm publish on v* tag with provenance), YAML form-based issue templates (bug_report.yml + feature_request.yml), expanded PR template (description, related issues, change type, checklist, screenshots) | E2E job omitted from CI (Phase 21 deferred); used YAML form templates instead of Markdown issue templates; added npm provenance via id-token permission |
+| 2026-03-15 | 24 | Build scripts & release pipeline: clean.ts (dist + optional coverage/storybook-static/.turbo via --all), build.ts (clean→typecheck→tsup→verify with size checks), release.ts (dirty check→tests→build→version bump→changelog update→git tag→push, --dry-run support). Added tsx devDep. Updated package.json scripts (clean, clean:all, prepublishOnly, release). | Added tsx as devDep (was missing); prepublishOnly now runs full build.ts pipeline; release --dry-run verified end-to-end |
 
 <!--
 Example entries:

--- a/package.json
+++ b/package.json
@@ -57,10 +57,12 @@
     "test:watch": "vitest --config config/vitest.config.ts",
     "test:coverage": "vitest run --coverage --config config/vitest.config.ts",
     "test:e2e": "playwright test",
-    "clean": "rm -rf dist",
+    "clean": "tsx scripts/clean.ts",
+    "clean:all": "tsx scripts/clean.ts --all",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "tsx scripts/build.ts",
+    "release": "tsx scripts/release.ts",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -108,6 +110,7 @@
     "react-dom": "^19.2.4",
     "storybook": "^8.6.0",
     "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.1.0"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,38 @@
-Helper scripts for releases and automation (changesets, publish helpers).
+# Scripts
 
-Add executable scripts here when the release flow is implemented.
+Build, clean, and release automation scripts. All scripts are written in TypeScript and run via `tsx`.
+
+## Available Scripts
+
+### `clean.ts`
+
+Removes build artifacts.
+
+```bash
+yarn clean            # removes dist/
+yarn clean:all        # also removes coverage/, storybook-static/, .turbo/
+```
+
+### `build.ts`
+
+Full build pipeline: clean → type-check → tsup bundle → verify output.
+
+```bash
+yarn tsx scripts/build.ts                  # full build
+yarn tsx scripts/build.ts --skip-typecheck # skip type-check (CI use)
+```
+
+The `prepublishOnly` hook runs this automatically before `npm publish`.
+
+### `release.ts`
+
+Semi-automated release: tests → build → version bump → changelog update → git tag → push (triggers CI publish).
+
+```bash
+yarn release patch        # 0.1.0 → 0.1.1
+yarn release minor        # 0.1.0 → 0.2.0
+yarn release major        # 0.1.0 → 1.0.0
+yarn release --dry-run patch   # preview without committing
+```
+
+The push of the `v*` tag triggers the GitHub Actions release workflow (`.github/workflows/release.yml`), which publishes to npm with provenance.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,9 +1,84 @@
 /**
- * Build script — runs tsup and reports output.
- * Usage: npx tsx scripts/build.ts
+ * Build script — clean, type-check, bundle with tsup, and verify output.
+ *
+ * Usage:
+ *   npx tsx scripts/build.ts             # full build (clean → typecheck → tsup → verify)
+ *   npx tsx scripts/build.ts --skip-typecheck   # skip type-check (for CI where it runs separately)
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — build or verification failed
  */
 import { execSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-console.log('Building with tsup...');
-execSync('yarn build', { stdio: 'inherit', cwd: import.meta.dirname + '/..' });
-console.log('Build complete.');
+const root = resolve(import.meta.dirname, '..');
+const args = process.argv.slice(2);
+const skipTypecheck = args.includes('--skip-typecheck');
+
+/** Expected output files and their minimum sizes (bytes). */
+const EXPECTED_FILES: Array<{ path: string; minSize: number }> = [
+  { path: 'dist/index.js', minSize: 1000 },
+  { path: 'dist/index.cjs', minSize: 1000 },
+  { path: 'dist/index.d.ts', minSize: 500 },
+  { path: 'dist/index.css', minSize: 500 },
+];
+
+function run(label: string, command: string): void {
+  console.log(`\n▸ ${label}`);
+  try {
+    execSync(command, { stdio: 'inherit', cwd: root });
+  } catch {
+    console.error(`\n✗ Failed: ${label}`);
+    process.exit(1);
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  return `${kb.toFixed(2)} KB`;
+}
+
+// ── Step 1: Clean ──────────────────────────────────────────────────
+run('Cleaning previous build', 'npx tsx scripts/clean.ts');
+
+// ── Step 2: Type-check ─────────────────────────────────────────────
+if (skipTypecheck) {
+  console.log('\n▸ Type-check skipped (--skip-typecheck)');
+} else {
+  run('Type-checking', 'yarn typecheck');
+}
+
+// ── Step 3: Bundle with tsup ───────────────────────────────────────
+run('Building with tsup', 'yarn tsup');
+
+// ── Step 4: Verify output ──────────────────────────────────────────
+console.log('\n▸ Verifying dist output');
+let allGood = true;
+
+for (const { path: filePath, minSize } of EXPECTED_FILES) {
+  const abs = resolve(root, filePath);
+  if (!existsSync(abs)) {
+    console.error(`  ✗ Missing: ${filePath}`);
+    allGood = false;
+    continue;
+  }
+  const size = statSync(abs).size;
+  if (size < minSize) {
+    console.error(
+      `  ✗ ${filePath} is suspiciously small (${formatSize(size)}, expected ≥${formatSize(minSize)})`,
+    );
+    allGood = false;
+    continue;
+  }
+  console.log(`  ✓ ${filePath} (${formatSize(size)})`);
+}
+
+if (!allGood) {
+  console.error('\n✗ Build verification failed.');
+  process.exit(1);
+}
+
+console.log('\n✓ Build completed and verified successfully.');

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -1,21 +1,40 @@
 /**
- * Clean script — removes build artifacts.
- * Usage: npx tsx scripts/clean.ts
+ * Clean script — removes build artifacts and caches.
+ *
+ * Usage:
+ *   npx tsx scripts/clean.ts          # clean build artifacts only
+ *   npx tsx scripts/clean.ts --all    # include caches (coverage, storybook, .turbo)
  */
-import { rmSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { rmSync, existsSync, statSync } from 'node:fs';
+import { resolve, relative } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
-const dirs = ['dist', 'storybook-static'];
+const args = process.argv.slice(2);
+const cleanAll = args.includes('--all');
+
+/** Directories always cleaned (build output). */
+const buildDirs = ['dist'];
+
+/** Directories only cleaned with --all flag (caches & generated). */
+const cacheDirs = ['coverage', 'storybook-static', '.turbo'];
+
+const dirs = cleanAll ? [...buildDirs, ...cacheDirs] : buildDirs;
+
+let removed = 0;
 
 for (const dir of dirs) {
   const target = resolve(root, dir);
   if (existsSync(target)) {
+    const stat = statSync(target);
     rmSync(target, { recursive: true, force: true });
-    console.log(`✓ Removed ${dir}/`);
+    console.log(`  ✓ Removed ${relative(root, target)}/`);
+    removed++;
   } else {
-    console.log(`○ ${dir}/ does not exist, skipping`);
+    console.log(`  ○ ${dir}/ does not exist, skipping`);
   }
 }
 
-console.log('Clean complete.');
+console.log(`\nClean complete. Removed ${removed} director${removed === 1 ? 'y' : 'ies'}.`);
+if (!cleanAll) {
+  console.log('Tip: use --all to also remove coverage, storybook-static, and .turbo.');
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,9 +1,162 @@
 /**
- * Release automation script — placeholder for future CI/CD integration.
- * Usage: npx tsx scripts/release.ts
+ * Semi-automated release script.
  *
- * TODO: Implement version bumping, changelog generation, and npm publish.
+ * Steps:
+ *   1. Ensure working directory is clean
+ *   2. Run full test suite
+ *   3. Build and verify
+ *   4. Bump version (patch/minor/major via CLI arg)
+ *   5. Update CHANGELOG.md with release date
+ *   6. Commit version bump + changelog
+ *   7. Create git tag
+ *   8. Push tag (triggers GitHub Actions release workflow)
+ *
+ * Usage:
+ *   npx tsx scripts/release.ts patch        # 0.1.0 → 0.1.1
+ *   npx tsx scripts/release.ts minor        # 0.1.0 → 0.2.0
+ *   npx tsx scripts/release.ts major        # 0.1.0 → 1.0.0
+ *   npx tsx scripts/release.ts --dry-run patch   # preview without committing
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — failure or validation error
  */
-console.log('Release script is not yet implemented.');
-console.log('Use `npm publish` or `yarn npm publish` manually for now.');
-process.exit(1);
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const args = process.argv.slice(2);
+
+const dryRun = args.includes('--dry-run');
+const bumpType = args.find((a) => ['patch', 'minor', 'major'].includes(a));
+
+if (!bumpType) {
+  console.error('Usage: npx tsx scripts/release.ts [--dry-run] <patch|minor|major>');
+  console.error('  e.g. npx tsx scripts/release.ts patch');
+  process.exit(1);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function run(label: string, command: string, opts?: { silent?: boolean }): string {
+  console.log(`\n▸ ${label}`);
+  if (dryRun && command.match(/git (commit|tag|push)/)) {
+    console.log(`  [dry-run] Would run: ${command}`);
+    return '';
+  }
+  try {
+    const output = execSync(command, {
+      cwd: root,
+      stdio: opts?.silent ? 'pipe' : 'inherit',
+      encoding: 'utf-8',
+    });
+    return typeof output === 'string' ? output.trim() : '';
+  } catch {
+    console.error(`\n✗ Failed: ${label}`);
+    process.exit(1);
+  }
+}
+
+function bumpVersion(current: string, type: string): string {
+  const [major, minor, patch] = current.split('.').map(Number);
+  switch (type) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      throw new Error(`Unknown bump type: ${type}`);
+  }
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ── Step 1: Check working directory ────────────────────────────────
+console.log('🚀 Starting release process...');
+if (dryRun) {
+  console.log('   (dry-run mode — no commits or tags will be created)\n');
+}
+
+const status = run('Checking working directory', 'git status --porcelain', { silent: true });
+if (status && !dryRun) {
+  console.error('\n✗ Working directory is not clean. Commit or stash changes first.');
+  console.error(status);
+  process.exit(1);
+}
+
+// ── Step 2: Run tests ──────────────────────────────────────────────
+run('Running test suite', 'yarn test');
+
+// ── Step 3: Build and verify ───────────────────────────────────────
+run('Building library', 'npx tsx scripts/build.ts --skip-typecheck');
+
+// ── Step 4: Bump version ───────────────────────────────────────────
+const pkgPath = resolve(root, 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+const currentVersion = pkg.version as string;
+const nextVersion = bumpVersion(currentVersion, bumpType);
+
+console.log(`\n▸ Version bump: ${currentVersion} → ${nextVersion} (${bumpType})`);
+
+if (!dryRun) {
+  pkg.version = nextVersion;
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
+  console.log('  ✓ Updated package.json');
+}
+
+// ── Step 5: Update CHANGELOG.md ────────────────────────────────────
+const changelogPath = resolve(root, 'CHANGELOG.md');
+const changelog = readFileSync(changelogPath, 'utf-8');
+
+// Replace [Unreleased] section marker or add a new dated section
+const unreleasedHeader = '## [Unreleased]';
+const datePattern = /## \[\d+\.\d+\.\d+\].*$/m;
+
+let updatedChangelog: string;
+if (changelog.includes(unreleasedHeader)) {
+  // Replace [Unreleased] with the new version + date, add new [Unreleased] above
+  updatedChangelog = changelog.replace(
+    unreleasedHeader,
+    `${unreleasedHeader}\n\n## [${nextVersion}] - ${today()}`,
+  );
+  console.log(`  ✓ Added [${nextVersion}] section to CHANGELOG.md`);
+} else if (datePattern.test(changelog)) {
+  // Insert the new version before the first existing version
+  updatedChangelog = changelog.replace(
+    datePattern,
+    `## [${nextVersion}] - ${today()}\n\n$&`,
+  );
+  console.log(`  ✓ Inserted [${nextVersion}] section into CHANGELOG.md`);
+} else {
+  console.log('  ○ Could not find a suitable place in CHANGELOG.md, skipping update');
+  updatedChangelog = changelog;
+}
+
+if (!dryRun && updatedChangelog !== changelog) {
+  writeFileSync(changelogPath, updatedChangelog, 'utf-8');
+}
+
+// ── Step 6: Commit ─────────────────────────────────────────────────
+run('Committing version bump', `git add -A && git commit -m 'chore(release): v${nextVersion}'`);
+
+// ── Step 7: Create tag ─────────────────────────────────────────────
+run('Creating git tag', `git tag -a v${nextVersion} -m 'Release v${nextVersion}'`);
+
+// ── Step 8: Push tag ───────────────────────────────────────────────
+run('Pushing tag to origin', `git push origin v${nextVersion}`);
+
+// ── Done ───────────────────────────────────────────────────────────
+console.log(`\n${'─'.repeat(50)}`);
+if (dryRun) {
+  console.log(`✓ Dry run complete. Would release v${nextVersion}.`);
+  console.log('  Run without --dry-run to perform the actual release.');
+} else {
+  console.log(`✓ Released v${nextVersion} successfully!`);
+  console.log('  The GitHub Actions release workflow will publish to npm.');
+  console.log(`  Monitor: https://github.com/Ndevu12/RichTextEditor/actions`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
+"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
   version: 0.27.4
   resolution: "esbuild@npm:0.27.4"
   dependencies:
@@ -4208,6 +4208,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.6"
   checksum: 10c0/d6a7d6afca375779a4b307738c9e80dbf7afc0bdbe5948768d54ab9653c865523d8920e670991a925936eb524b7cb6a6361d199a760b21d0ca7620194455aa4b
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.13.6
+  resolution: "get-tsconfig@npm:4.13.6"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/bab6937302f542f97217cbe7cbbdfa7e85a56a377bc7a73e69224c1f0b7c9ae8365918e55752ae8648265903f506c1705f63c0de1d4bab1ec2830fef3e539a1a
   languageName: node
   linkType: hard
 
@@ -6246,6 +6255,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.22.1, resolve@npm:^1.22.8":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
@@ -6351,6 +6367,7 @@ __metadata:
     react-dom: "npm:^19.2.4"
     storybook: "npm:^8.6.0"
     tsup: "npm:^8.5.1"
+    tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
     vitest: "npm:^4.1.0"
@@ -7201,6 +7218,22 @@ __metadata:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
   checksum: 10c0/86b0a5ee5533cf5363431ffaf6a244d06fbc80e3a739f216a121a336b28e663d521bae1d3b2d9ba7d479cb4b5f7dcb5e0722e169d3daf664c78f0d68676fa06a
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.21.0":
+  version: 4.21.0
+  resolution: "tsx@npm:4.21.0"
+  dependencies:
+    esbuild: "npm:~0.27.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/f5072923cd8459a1f9a26df87823a2ab5754641739d69df2a20b415f61814322b751fa6be85db7c6ec73cf68ba8fac2fd1cfc76bdb0aa86ded984d84d5d2126b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- clean.ts: removes dist/, optional --all for coverage/storybook/.turbo
- build.ts: clean → typecheck → tsup → verify (file existence + size)
- release.ts: dirty check → tests → build → version bump → changelog update → git tag → push (triggers CI publish). Supports --dry-run.
- Added tsx as devDependency for running TS scripts
- Updated package.json: clean, clean:all, prepublishOnly, release
- Updated scripts/README.md with full usage documentation


