### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Dialogs/ImageDialog.tsx
+++ b/src/components/Dialogs/ImageDialog.tsx
@@ -225,7 +225,7 @@ export function ImageDialog() {
       // Only allow http/https for URL-based previews. Other schemes, including
       // generic data: URLs, are rejected to avoid loading potentially unsafe content.
       if (scheme === 'http' || scheme === 'https') {
-        return trimmed;
+        return parsed.toString();
       }
 
       return null;


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/RichTextEditor/security/code-scanning/7](https://github.com/Ndevu12/RichTextEditor/security/code-scanning/7)

General fix: ensure untrusted URL input is canonicalized and strictly allowlisted immediately before being written to URL-bearing DOM attributes, and render nothing if validation fails.

Best fix here (without changing functionality): harden `getSafePreviewSrc()` so it returns a canonical URL string (`parsed.toString()`) only for `http`/`https`, and use that sanitized value directly in `img src`. This keeps current behavior (preview only for http/https and file/base64 path) while making the sink-safe transformation explicit.

Change needed in `src/components/Dialogs/ImageDialog.tsx`:
- In `getSafePreviewSrc`, replace `return trimmed;` with `return parsed.toString();` after scheme allowlist check.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
